### PR TITLE
fix: add missing `/` to symlink in setup script

### DIFF
--- a/scripts/new-application-test-suite-setup.sh
+++ b/scripts/new-application-test-suite-setup.sh
@@ -72,7 +72,7 @@ printf "%s\n" "${RESOURCE_FILE_TEMPLATE}" > "${RESOURCE_FILE}"
 mkdir -p "${GENERIC_DIR}"
 touch "${EMPTY_PNG}"
 cd "${APP_DIR}" || exit
-ln -s "../../common" "common"
+ln -s "../../common/" "common"
 cd - || exit
 
 echo "All done! Created the following application directory:"


### PR DESCRIPTION
The symlink created by the setup script misses a trailing `/` compared with the [CI check](https://github.com/canonical/ubuntu-gui-testing/blob/9dd4b7e3d50dda261033ed8162a26742db01f8b5/.github/workflows/symlink-checker.yaml#L36).