### PR TITLE
Don't access yarf keywords with library name prefix

### DIFF
--- a/common/common.resource
+++ b/common/common.resource
@@ -19,64 +19,64 @@ EzClick
 Open Terminal
     [Documentation]         Open terminal with ctrl+alt+T
     ${combo}    Create List    Alt_L    Control_L    t
-    PlatformHid.Keys Combo    ${combo}
-    PlatformVideoInput.Match Text    ubuntu@ubuntu    15
+    Keys Combo    ${combo}
+    Match Text    ubuntu@ubuntu    15
 
 Run Sudo Command In Terminal
     [Documentation]         Run a command prepended with sudo in the terminal
     [Arguments]    ${command}
     ${ampersand}    Create List    Shift_L    7
     ${space}    Create List    space
-    PlatformHid.Type String    clear
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Type String    ${command}
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Type String    echo FINISHED-HIT
+    Type String    clear
+    Keys Combo    ${space}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${space}
+    Type String    ${command}
+    Keys Combo    ${space}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${space}
+    Type String    echo FINISHED-HIT
     BuiltIn.Sleep    2    # hacky
     ${enter}    Create List    Return
-    PlatformHid.Keys Combo    ${enter}
+    Keys Combo    ${enter}
     BuiltIn.Sleep    4    # hacky
-    PlatformHid.Type String    ubuntu
+    Type String    ubuntu
     BuiltIn.Sleep    2    # hacky
-    PlatformHid.Keys Combo    ${enter}
+    Keys Combo    ${enter}
     BuiltIn.Sleep    1    # hacky
-    PlatformVideoInput.Match Text    FINISHED-HIT    120
+    Match Text    FINISHED-HIT    120
 
 Run Command In Terminal
     [Documentation]         Run a command in the terminal
     [Arguments]    ${command}
     ${ampersand}    Create List    Shift_L    7
     ${space}    Create List    space
-    PlatformHid.Type String    clear
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Type String    ${command}
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${ampersand}
-    PlatformHid.Keys Combo    ${space}
-    PlatformHid.Type String    echo FINISHED-HIT
+    Type String    clear
+    Keys Combo    ${space}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${space}
+    Type String    ${command}
+    Keys Combo    ${space}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${ampersand}
+    Keys Combo    ${space}
+    Type String    echo FINISHED-HIT
     BuiltIn.Sleep    2    # hacky
     ${enter}    Create List    Return
-    PlatformHid.Keys Combo    ${enter}
+    Keys Combo    ${enter}
     BuiltIn.Sleep    2    # hacky
-    PlatformVideoInput.Match Text    FINISHED-HIT    120
+    Match Text    FINISHED-HIT    120
 
 Close Terminal
     [Documentation]         Close terminal with ctrl+shift+w
     ${combo}    Create List    Control_L    Shift_L    w
     FOR    ${_}    IN RANGE    30
-        ${terminal_finns}    Run Keyword And Return Status    PlatformVideoInput.Match Text    ubuntu@ubuntu    15
+        ${terminal_finns}    Run Keyword And Return Status    Match Text    ubuntu@ubuntu    15
         IF    not ${terminal_finns}      BREAK
-        PlatformHid.Keys Combo    ${combo}
+        Keys Combo    ${combo}
         BuiltIn.Sleep    1
     END
 
@@ -100,20 +100,20 @@ Start Application
     [Documentation]         Start an application from the command prompt
     [Arguments]    ${application}
     ${combo}    Create List    Alt_L    F2
-    PlatformHid.Keys Combo    ${combo}
-    PlatformVideoInput.Match Text    Run a Command    15
-    PlatformHid.Type String    ${application}
+    Keys Combo    ${combo}
+    Match Text    Run a Command    15
+    Type String    ${application}
     ${ret}    Create List    Return
-    PlatformHid.Keys Combo    ${ret}
+    Keys Combo    ${ret}
 
 Log In
     [Documentation]         Log in to desktop session
-    PlatformVideoInput.Match Text    Not listed    120
+    Match Text    Not listed    120
     ${ret}    Create List    Return
-    PlatformHid.Keys Combo    ${ret}
+    Keys Combo    ${ret}
     BuiltIn.Sleep    2
-    PlatformHid.Type String    ubuntu
+    Type String    ubuntu
     BuiltIn.Sleep    2
-    PlatformHid.Keys Combo    ${ret}
+    Keys Combo    ${ret}
     BuiltIn.Sleep    2
-    PlatformVideoInput.Match    ${X}/circle-of-friends.png    60
+    Match    ${X}/circle-of-friends.png    60

--- a/tests/chromium-test/chromium.resource
+++ b/tests/chromium-test/chromium.resource
@@ -13,7 +13,7 @@ ${Y}    ${CURDIR}
 Open Chromium
     [Documentation]         Open chromium browser
     Start Application    /snap/bin/chromium
-    PlatformVideoInput.Match Text    New Tab
+    Match Text    New Tab
 
 Install Mail Client
     [Documentation]         Install evolution debian package
@@ -26,18 +26,18 @@ Install Chromium
 Open Chromium Mail Link
     [Documentation]         Affirm the mailto chromium link works and opens evolution
     Start Application    /snap/bin/chromium wiki.ubuntu.com/DesktopTeam/TestPlans/Chromium
-    PlatformVideoInput.Match Text    Attachments
+    Match Text    Attachments
 
     ${combo}    Create List    Control_L    f
-    PlatformHid.Keys Combo    ${combo}
-    PlatformHid.Type String    mailto
+    Keys Combo    ${combo}
+    Type String    mailto
     ${esc}    Create List    Escape
     ${ret}    Create List    Return
-    PlatformHid.Keys Combo    ${esc}
-    PlatformHid.Keys Combo    ${ret}
+    Keys Combo    ${esc}
+    Keys Combo    ${ret}
 
 Match Mail Client
     [Documentation]         Ensure evolution is opened
-    PlatformVideoInput.Match Text    From
-    PlatformVideoInput.Match Text    To
-    PlatformVideoInput.Match Text    foobar@nospam.org
+    Match Text    From
+    Match Text    To
+    Match Text    foobar@nospam.org

--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -135,7 +135,7 @@ Encryption And File System Zfs Encryption
     ${matches}      Match Text        Encrypt with a passphrase using ZFS       20
     # for some reason, this indexing seems to differ from interactive terminal to in this resource file?
     # an extra [0]? weird, keep an eye on it. Will be solved by yarf PR anyway
-    PlatformHid.Move Pointer To Absolute    ${matches[0][0]['region'].left}      ${matches[0][0]['region'].top}
+    Move Pointer To Absolute    ${matches[0][0]['region'].left}      ${matches[0][0]['region'].top}
     # Move Pointer To ${T}/generic/encryption-and-file-system-show-advanced-zfs-encryption.png
     EzClick
     Move Pointer To ${T}/generic/next.png

--- a/tests/desktop-security-center/desktop-security-center.resource
+++ b/tests/desktop-security-center/desktop-security-center.resource
@@ -16,14 +16,14 @@ ${DEFAULT_RECOVERY_KEY}     27923-40354-64135-46675-37087-49770-10618-41883
 Open Security Center
     [Documentation]    Opens the Security Center
     Open Terminal
-    PlatformHid.Type String    desktop-security-center
-    PlatformHid.Keys Combo    Return
+    Type String    desktop-security-center
+    Keys Combo    Return
 
 Open Disk Encryption Tab
     [Documentation]    Opens the Disk Encryption Tab in the Security Center
     Move Pointer To ${Y}/generic/disk-icon.png
     EzClick
-    PlatformVideoInput.Match    ${Y}/generic/disk-icon-selected.png
+    Match    ${Y}/generic/disk-icon-selected.png
 
 Check Recovery Key Success
     [Documentation]    Check a valid recovery key in the Security Center
@@ -32,11 +32,11 @@ Check Recovery Key Success
     EzClick
     Move Pointer To XXXX
     EzClick
-    PlatformHid.Type String    ${RECOVERY_KEY}
+    Type String    ${RECOVERY_KEY}
     Move Pointer To ${Y}/generic/check-recovery-key-button.png
     EzClick
     Authenticate With Polkit
-    PlatformVideoInput.Match    ${Y}/generic/check-recovery-key-success.png
+    Match    ${Y}/generic/check-recovery-key-success.png
 
 Change Passphrase
     [Documentation]    Changes the systems passphrase from the Security Centers Disk Encryption Page
@@ -45,23 +45,23 @@ Change Passphrase
     EzClick
     Move Pointer To Current Passphrase
     EzClick
-    PlatformHid.Type String    ${old}
+    Type String    ${old}
     Move Pointer To New Passphrase
     EzClick
-    PlatformHid.Type String    ${new}
+    Type String    ${new}
     Move Pointer To Confirm Passphrase
     EzClick
-    PlatformHid.Type String    ${new}
+    Type String    ${new}
     Move Pointer To ${Y}/generic/change-button.png
     EzClick
-    PlatformVideoInput.Match    ${Y}/generic/change-passphrase-success.png
+    Match    ${Y}/generic/change-passphrase-success.png
 
 Boot With Passphrase
     [Documentation]    Boot the system using a passphrase
     [Arguments]    ${passphrase}
-    PlatformVideoInput.Match Text    Please enter the passphrase for volume    120
-    PlatformHid.Type String    ${passphrase}
-    PlatformHid.Keys Combo    Return
+    Match Text    Please enter the passphrase for volume    120
+    Type String    ${passphrase}
+    Keys Combo    Return
 
 Check Recovery Key Failure
     [Documentation]    Check an invalid recovery key in the Security Center
@@ -69,11 +69,11 @@ Check Recovery Key Failure
     EzClick
     Move Pointer To XXXX
     EzClick
-    PlatformHid.Type String    00000-00000-00000-00000-00000-00000-00000-00000
+    Type String    00000-00000-00000-00000-00000-00000-00000-00000
     Move Pointer To ${Y}/generic/check-recovery-key-button.png
     EzClick
     Authenticate With Polkit
-    PlatformVideoInput.Match    ${Y}/generic/check-recovery-key-failure.png
+    Match    ${Y}/generic/check-recovery-key-failure.png
 
 Replace Recovery Key
     [Documentation]    Replace the systems recovery key, validating it is saved to a file
@@ -88,7 +88,7 @@ Replace Recovery Key
     # QR code generates and shows recovery key
     Move Pointer to "Show QR code"
     EzClick
-    PlatformVideoInput.Match Text    ${recovery_key}
+    Match Text    ${recovery_key}
     Move Pointer To ${Y}/generic/cross-button.png
     EzClick
     # We can save to a file
@@ -100,33 +100,33 @@ Replace Recovery Key
     EzCLick
     Move Pointer To ${Y}/generic/replace-recovery-key-button.png
     EzClick
-    PlatformVideoInput.Match    ${Y}/generic/replace-recovery-key-success.png
+    Match    ${Y}/generic/replace-recovery-key-success.png
     Move Pointer To ${Y}/generic/cross-button.png
     EzCLick
     Move Pointer To ${Y}/generic/cross-button.png
     EzCLick
     # cat recovery-key.txt to validate we saved the key
-    PlatformHid.Type String    cat /home/ubuntu/recovery-key.txt
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match Text    ${recovery_key}
+    Type String    cat /home/ubuntu/recovery-key.txt
+    Keys Combo    Return
+    Match Text    ${recovery_key}
     RETURN    ${recovery_key}
 
 Test Unlock With Recovery Key
     [Documentation]    Reboot the system and boot using the recovery key
     [Arguments]    ${recovery_key}
     Start Application    reboot
-    Wait Until Keyword Succeeds    25 seconds    3 seconds    PlatformVideoInput.Match Text    "Please enter the passphrase"
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match Text    "Please enter the recovery"
-    PlatformHid.Type String    ${recovery_key}
-    PlatformHid.Keys Combo    Return
+    Wait Until Keyword Succeeds    25 seconds    3 seconds    Match Text    "Please enter the passphrase"
+    Keys Combo    Return
+    Match Text    "Please enter the recovery"
+    Type String    ${recovery_key}
+    Keys Combo    Return
     Log In
 
 Authenticate With Polkit
     [Documentation]    Authenticate using a polkit prompt
-    PlatformVideoInput.Match Text    "Authentication Required"
+    Match Text    "Authentication Required"
     Move Pointer To Password
     EzCLick
-    PlatformHid.Type String    ubuntu
+    Type String    ubuntu
     Move Pointer To Authenticate
     EzCLick

--- a/tests/firefox-example/firefox-example.resource
+++ b/tests/firefox-example/firefox-example.resource
@@ -13,11 +13,11 @@ ${Y}    ${CURDIR}
 Open Firefox
     [Documentation]         Open the firefox browser
     Start Application    firefox
-    PlatformVideoInput.Match Text    Firefox    60
+    Match Text    Firefox    60
 
 Open New Tab
     [Documentation]         Open a new tab
     Move Pointer To ${Y}/generic/new-tab.png
     EzClick
-    PlatformVideoInput.Match    ${Y}/firefox-example-new-tab/new-tab.png
-    # PlatformVideoInput.Match Text    New Tab    40
+    Match    ${Y}/firefox-example-new-tab/new-tab.png
+    # Match Text    New Tab    40

--- a/tests/firmware-updater/firmware-updater.resource
+++ b/tests/firmware-updater/firmware-updater.resource
@@ -16,30 +16,30 @@ Open Firmware Updater
     Open Terminal
 
     # Become root
-    PlatformHid.Type String    sudo -s
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match Text    [sudo] password
-    PlatformHid.Type String    ubuntu
-    PlatformHid.Keys Combo    Return
+    Type String    sudo -s
+    Keys Combo    Return
+    Match Text    [sudo] password
+    Type String    ubuntu
+    Keys Combo    Return
 
     # Write firmware-updater config file to make it pretend updating the fwupd
     # test device affects TPM FDE so that it triggers the recovery key dialog
-    PlatformHid.Type String    mkdir -p /root/.config/firmware-updater
-    PlatformHid.Keys Combo    Return
+    Type String    mkdir -p /root/.config/firmware-updater
+    Keys Combo    Return
     Builtin.Sleep    2
-    PlatformHid.Type String    echo 'testDeviceAffectsFde
-    PlatformHid.Keys Combo    Shift_L    ;
-    PlatformHid.Keys Combo    space
-    PlatformHid.Type String    true'
-    PlatformHid.Keys Combo    Shift_L    .
-    PlatformHid.Type String    /root/.config/firmware-updater/firmware-updater.yml
-    PlatformHid.Keys Combo    Return
+    Type String    echo 'testDeviceAffectsFde
+    Keys Combo    Shift_L    ;
+    Keys Combo    space
+    Type String    true'
+    Keys Combo    Shift_L    .
+    Type String    /root/.config/firmware-updater/firmware-updater.yml
+    Keys Combo    Return
     Builtin.Sleep    5
 
     # Run firmware-updater as root outside snap confimenet
-    PlatformHid.Type String    /snap/firmware-updater/current/bin/firmware-updater
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match Text    Firmware Updater    60
+    Type String    /snap/firmware-updater/current/bin/firmware-updater
+    Keys Combo    Return
+    Match Text    Firmware Updater    60
 
 Update Fake Webcam
     [Documentation]         Make sure fake webcam device is selected
@@ -55,16 +55,16 @@ Update Fake Webcam
     EzClick
     # There seem to be some issues with sending long strings over VNC - I had
     # to break it in half here and add a sleep in between to get it to work
-    PlatformHid.Type String    00000-00000-00000-00000
+    Type String    00000-00000-00000-00000
     Sleep    1
-    PlatformHid.Type String    -00000-00000-00000-00000
+    Type String    -00000-00000-00000-00000
     Move Pointer To ${Y}/generic/confirm-button.png
     EzClick
-    PlatformVideoInput.Match Text    Recovery key does not work
+    Match Text    Recovery key does not work
 
     # Enter correct recovery key
-    PlatformHid.Keys Combo    Tab
-    PlatformHid.Type String    ${RECOVERY_KEY}
+    Keys Combo    Tab
+    Type String    ${RECOVERY_KEY}
     Move Pointer To ${Y}/generic/confirm-button.png
     EzClick
-    PlatformVideoInput.Match    ${Y}/generic/update-done.png    60
+    Match    ${Y}/generic/update-done.png    60

--- a/tests/gnome-shell/gnome-shell-basic/gnome-shell-basic.robot
+++ b/tests/gnome-shell/gnome-shell-basic/gnome-shell-basic.robot
@@ -22,48 +22,48 @@ Shell Log In
 Open Apps
     [Documentation]         Open app centre
     Click On Dock App    Files
-    PlatformVideoInput.Match Text    Files
-    PlatformVideoInput.Match Text    Home
-    PlatformVideoInput.Match Text    Recent
+    Match Text    Files
+    Match Text    Home
+    Match Text    Recent
     Click On Dock App    App Center
-    PlatformVideoInput.Match Text    App Center
-    PlatformVideoInput.Match Text    Explore
-    PlatformVideoInput.Match Text    Featured
+    Match Text    App Center
+    Match Text    Explore
+    Match Text    Featured
 
 Alt Tab
     [Documentation]         Alt tab back to Nautilus
-    PlatformHid.Keys Combo    Alt    Tab
-    PlatformVideoInput.Match Text    Files
-    PlatformVideoInput.Match Text    Home
-    PlatformVideoInput.Match Text    Recent
+    Keys Combo    Alt    Tab
+    Match Text    Files
+    Match Text    Home
+    Match Text    Recent
     Close All Windows
 
 Open Files
     [Documentation]         Open Nautilus again
     Click Circle of Friends
-    PlatformHid.Type String    Files
-    PlatformVideoInput.Match Text    Files
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match Text    Recent
-    PlatformVideoInput.Match Text    Starred
+    Type String    Files
+    Match Text    Files
+    Keys Combo    Return
+    Match Text    Recent
+    Match Text    Starred
     Click Text    Recent
 
 Window Switching
     [Documentation]         Switch between windows of Nautilus
     Move Pointer To ${Y}/generic/nautilus.png
     EzRightClick
-    PlatformVideoInput.Match Text    New Window
+    Match Text    New Window
     Click Text    New Window
     Click Image    ${Y}/generic/nautilus.png
-    PlatformVideoInput.Match Text    No Recent Files
-    PlatformHid.Keys Combo    Tab
-    PlatformHid.Keys Combo    Return
+    Match Text    No Recent Files
+    Keys Combo    Tab
+    Keys Combo    Return
 
 Notification Panel
     [Documentation]         Open the notification panel
     Move Pointer To Proportional (0.5, 0)
     EzClick
-    PlatformVideoInput.Match Text    Do Not Disturb
+    Match Text    Do Not Disturb
     Move Pointer To Proportional (0.5, 0)
     EzClick
 
@@ -76,19 +76,19 @@ Workspace Switching
     EzClick
     Move Pointer To Proportional (0.5, 0.5)
     EzClick
-    PlatformVideoInput.Match Text    Home
+    Match Text    Home
     # Switch to left workspace with keyboard
     Workspace Left
-    PlatformVideoInput.Match Text    Recent
+    Match Text    Recent
 
 Shell Lock
     [Documentation]         Lock the screen, and log back in
     Toggle System Panel
     Click Lock Button
-    PlatformHid.Keys Combo    Return
-    PlatformHid.Type String    ubuntu
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match    ${X}/circle-of-friends.png    60
+    Keys Combo    Return
+    Type String    ubuntu
+    Keys Combo    Return
+    Match    ${X}/circle-of-friends.png    60
 
 Shell Log Out
     [Documentation]         Log out of desktop environment

--- a/tests/gnome-shell/gnome-shell.resource
+++ b/tests/gnome-shell/gnome-shell.resource
@@ -18,17 +18,17 @@ Toggle System Panel
 Click Power Button
     [Documentation]    Click the power button in the system panel
     Click Image    ${Y}/generic/power-button.png
-    PlatformVideoInput.Match Text    "Log out..."
+    Match Text    "Log out..."
 
 User Log In
     [Documentation]    Log in a given user with password
     [Arguments]    ${username}    ${password}
-    PlatformVideoInput.Match Text    ${username}
+    Match Text    ${username}
     Click Text    ${username}
-    PlatformVideoInput.Match Text    Password
-    PlatformHid.Type String    ${password}
-    PlatformHid.Keys Combo    Return
-    PlatformVideoInput.Match    ${X}/circle-of-friends.png    60
+    Match Text    Password
+    Type String    ${password}
+    Keys Combo    Return
+    Match    ${X}/circle-of-friends.png    60
 
 Click Lock Button
     [Documentation]    Click the lock button in the system panel
@@ -38,12 +38,12 @@ Click Log Out
     [Documentation]    Click the log out button in the power system panel
     Click Text    Log Out...
     Click Text Nth    Log Out    1
-    PlatformVideoInput.Match Text    "Not listed"
+    Match Text    "Not listed"
 
 Click Circle of Friends
     [Documentation]    Click the circle of friends in the dock
     Click Image    ${Y}/generic/circle-of-friends.png
-    PlatformVideoInput.Match Text    "Type to search"
+    Match Text    "Type to search"
 
 EzRightClick
     [Documentation]    EZClick but with right click
@@ -54,18 +54,18 @@ EzRightClick
 
 Workspace Left
     [Documentation]    Switch to the left workspace via the keyboard
-    PlatformHid.Keys Combo    Super    Page_Up
+    Keys Combo    Super    Page_Up
 
 Workspace Right
     [Documentation]    Switch to the right workspace via the keyboard
-    PlatformHid.Keys Combo    Super    Page_Down
+    Keys Combo    Super    Page_Down
 
 Move Pointer To Text Nth
     [Documentation]    Moves the pointer to the nth occurrence of the text
     [Arguments]    ${text}    ${n}
     # https://github.com/canonical/ubuntu-gui-testing/pull/5/files#diff-88f4ce867cfe634d1771f32a4f5b3ebc70348744992fc4305d79d3e422845524R68-R73
-    ${match}    PlatformVideoInput.Match Text    ${text}
-    PlatformHid.Move Pointer To Absolute
+    ${match}    Match Text    ${text}
+    Move Pointer To Absolute
     ...    x=${{(${match[0][${n}]['region'].right} + ${match[0][${n}]['region'].left})//2}}
     ...    y=${{(${match[0][${n}]['region'].bottom} + ${match[0][${n}]['region'].top})//2}}
 
@@ -91,7 +91,7 @@ Look For Text In Screen
     [Documentation]    Look for the given text on the screen without waiting, returning
     ...    the string, or empty if nothing is found.
     [Arguments]    ${target_txt}
-    ${txt}    PlatformVideoInput.Read Text
+    ${txt}    Read Text
     ${split}    Split String    ${txt}    \n
 
     FOR    ${t}    IN    @{split}
@@ -131,7 +131,7 @@ Try Match
     ...    Does nothing if no match is found instead of the usual fail.
     [Arguments]    ${template}    ${timeout}=1
     TRY
-        ${match}    PlatformVideoInput.Match    ${template}    ${timeout}
+        ${match}    Match    ${template}    ${timeout}
         RETURN    ${match}
     EXCEPT
         Log To Console    Try Match failed to match

--- a/tests/multipass/multipass.resource
+++ b/tests/multipass/multipass.resource
@@ -17,16 +17,16 @@ Install Multipass
 Open Multipass
     [Documentation]    Open Multipass and verify that it has loaded
     Start Application    /snap/bin/multipass.gui
-    PlatformVideoInput.Match Text    Multipass
-    PlatformVideoInput.Match Text    Welcome to Multipass
-    PlatformVideoInput.Match Text    Get an instant VM or application in seconds
+    Match Text    Multipass
+    Match Text    Welcome to Multipass
+    Match Text    Get an instant VM or application in seconds
 
 Verify No Instances
     [Documentation]    Verify that there are no instances currently, starting from the catalogue screen.
     Move Pointer To ${Y}/generic/instances.png
-    PlatformVideoInput.Match Text    Instances
+    Match Text    Instances
     EzClick
-    PlatformVideoInput.Match Text    Zero Intances
+    Match Text    Zero Intances
     Move Pointer To ${Y}/generic/catalogue.png
     EzClick
 
@@ -40,28 +40,28 @@ Launch Instance
     [Documentation]    Launch a random instance and ensure it ends up in a running state
     Move Pointer To ${y}/generic/launch.png
     EzClick
-    PlatformVideoInput.Match Text    Launching
-    PlatformVideoInput.Match Text    Downloading Image
+    Match Text    Launching
+    Match Text    Downloading Image
     Move Pointer To ${y}/generic/instance-details.png
     EzClick
     Move Pointer To Proportional (0, 0)
     Wait Until Keyword Succeeds
     ...    600 seconds
     ...    5 seconds
-    ...    PlatformVideoInput.Match
+    ...    Match
     ...    ${y}/generic/instance-details-running.png
 
 Return to Catalogue
     [Documentation]    Return to the Catalogue from Instances
     Move Pointer To ${Y}/generic/catalogue.png
-    PlatformVideoInput.Match Text    Catalogue
+    Match Text    Catalogue
     EzClick
-    PlatformVideoInput.Match Text    Welcome to Multipass
+    Match Text    Welcome to Multipass
 
 Delete Single Instance
     [Documentation]    Delete a single existing instance
     Move Pointer To ${Y}/generic/instances-1.png
-    PlatformVideoInput.Match Text    Instances
+    Match Text    Instances
     EzClick
     Move Pointer To Proportional (0, 0)
     Move Pointer To ${Y}/generic/instances-checkbox.png
@@ -71,7 +71,7 @@ Delete Single Instance
     BuiltIn.Sleep    1
     Move Pointer To ${Y}/generic/instances-delete.png
     EzClick
-    Wait Until Keyword Succeeds    15 seconds    3 seconds    PlatformVideoInput.Match Text    Zero Instances
+    Wait Until Keyword Succeeds    15 seconds    3 seconds    Match Text    Zero Instances
 
 Close Multipass
     [Documentation]    Close Multipass
@@ -82,5 +82,5 @@ Close Multipass
     ...    2 seconds
     ...    Run Keyword And Expect Error
     ...    *
-    ...    PlatformVideoInput.Match Text
+    ...    Match Text
     ...    Multipass


### PR DESCRIPTION
This follows on from https://github.com/canonical/yarf/pull/35/, where the requirement to prefix a keyword like `Match Text` with the library `PlatformVideoInput` is removed.

Yippee! Now we get rid of all of these usages of `PlatformVideoInput` and `PlatformHid`.