### PR TITLE
rpi: Increase Name Select match timeout for GUI installer test

### DIFF
--- a/tests/raspberry-pi/questing/core/01-gui-install/install.robot
+++ b/tests/raspberry-pi/questing/core/01-gui-install/install.robot
@@ -71,7 +71,7 @@ Name Select
     Match    ${CURDIR}/snapshots/templates/next_btn.jpg
     Click LEFT Button on ${CURDIR}/snapshots/templates/next_btn.jpg
     Move Pointer To (100, 100)
-    Match    ${CURDIR}/snapshots/screens/screen_06.jpg
+    Match    ${CURDIR}/snapshots/screens/screen_06.jpg    40
 
 Password Select
     [Documentation]    Enter a password


### PR DESCRIPTION
After the latest upload of gnome-initial-setup, it seems that the transition from username selection -> password selection screen is much more delayed. This change increases the timeout of that step to handle that.