### PR TITLE
Plan files: remove trailing - from test case name

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ There is also an optional section per test case, `requirements`. Usage of that i
 ```
 ---
 tests:
-  - Tpm-Fde-With-Passphrase:
+  Tpm-Fde-With-Passphrase:
     entrypoint: tests/desktop-installer/
     requirements:
       tpm: true

--- a/tests/desktop-security-center/plans/permission-prompting.yaml
+++ b/tests/desktop-security-center/plans/permission-prompting.yaml
@@ -1,4 +1,4 @@
 ---
 tests:
-  - Desktop-Security-Center-Camera-Permissions-Lifecycle:
+  Desktop-Security-Center-Camera-Permissions-Lifecycle:
     entrypoint: tests/desktop-security-center

--- a/tests/desktop-security-center/plans/tpm-fde.yaml
+++ b/tests/desktop-security-center/plans/tpm-fde.yaml
@@ -1,22 +1,22 @@
 ---
 tests:
-  - Desktop-Security-Center:
+  Desktop-Security-Center:
     entrypoint: "tests/desktop-security-center/"
     requirements:
       tpm: true
-  - Desktop-Security-Center-Tpm-Fde-Change-Passphrase:
+  Desktop-Security-Center-Tpm-Fde-Change-Passphrase:
     entrypoint: "tests/desktop-security-center/"
     requirements:
       tpm: true
-  - Desktop-Security-Center-Check-Key-Success:
+  Desktop-Security-Center-Check-Key-Success:
     entrypoint: "tests/desktop-security-center/"
     requirements:
       tpm: true
-  - Desktop-Security-Center-Check-Key-Failure:
+  Desktop-Security-Center-Check-Key-Failure:
     entrypoint: "tests/desktop-security-center/"
     requirements:
       tpm: true
-  - Desktop-Security-Center-Replace-Recovery-Key:
+  Desktop-Security-Center-Replace-Recovery-Key:
     entrypoint: "tests/desktop-security-center/"
     requirements:
       tpm: true

--- a/tests/firefox-example/plans/extended.yaml
+++ b/tests/firefox-example/plans/extended.yaml
@@ -1,6 +1,6 @@
 ---
 tests:
-  - Firefox-Example-Basic:
+  Firefox-Example-Basic:
     entrypoint: tests/firefox-example
-  - Firefox-Example-New-Tab:
+  Firefox-Example-New-Tab:
     entrypoint: tests/firefox-example

--- a/tests/firefox-example/plans/regular.yaml
+++ b/tests/firefox-example/plans/regular.yaml
@@ -1,3 +1,4 @@
 ---
-robot_files:
-    - "tests/firefox-example/firefox-example-basic/firefox-example-basic.robot"
+tests:
+  Firefox-Example-Basic:
+    entrypoint: tests/firefox-example/

--- a/tests/firmware-updater/plans/bitlocker.yaml
+++ b/tests/firmware-updater/plans/bitlocker.yaml
@@ -1,10 +1,10 @@
 ---
 tests:
-  - Firmware-Updater-Bitlocker-Dbx:
+  Firmware-Updater-Bitlocker-Dbx:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true
-  - Firmware-Updater-Bitlocker-Ca:
+  Firmware-Updater-Bitlocker-Ca:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true

--- a/tests/firmware-updater/plans/plain.yaml
+++ b/tests/firmware-updater/plans/plain.yaml
@@ -1,10 +1,10 @@
 ---
 tests:
-  - Firmware-Updater-Dbx:
+  Firmware-Updater-Dbx:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true
-  - Firmware-Updater-Ca:
+  Firmware-Updater-Ca:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true

--- a/tests/firmware-updater/plans/tpm-fde.yaml
+++ b/tests/firmware-updater/plans/tpm-fde.yaml
@@ -1,14 +1,14 @@
 ---
 tests:
-  - Firmware-Updater-Tpm-Fde-Fake-Webcam:
+  Firmware-Updater-Tpm-Fde-Fake-Webcam:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true
-  - Firmware-Updater-Tpm-Fde-Dbx:
+  Firmware-Updater-Tpm-Fde-Dbx:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true
-  - Firmware-Updater-Tpm-Fde-Ca:
+  Firmware-Updater-Tpm-Fde-Ca:
     entrypoint: "tests/firmware-updater/"
     requirements:
       tpm: true

--- a/tests/gnome-shell/plans/regular.yaml
+++ b/tests/gnome-shell/plans/regular.yaml
@@ -1,4 +1,4 @@
 ---
 tests:
-  - Gnome-Shell-Basic:
+  Gnome-Shell-Basic:
     entrypoint: "tests/gnome-shell"

--- a/tests/multipass/plans/regular.yaml
+++ b/tests/multipass/plans/regular.yaml
@@ -1,4 +1,4 @@
 ---
 tests:
-  - Multipass-Basic:
+  Multipass-Basic:
     entrypoint: "tests/multipass/"

--- a/tests/prompting/plans/home-common-ui.yaml
+++ b/tests/prompting/plans/home-common-ui.yaml
@@ -1,3 +1,6 @@
 ---
-robot_files:
-  - "tests/prompting/prompting-home-gimp/prompting-home-gimp.robot"
+tests:
+  - Prompting-Home-Gimp:
+    entrypoint: tests/prompting/
+    requirements:
+      tpm: true

--- a/tests/prompting/plans/home-parallel.yaml
+++ b/tests/prompting/plans/home-parallel.yaml
@@ -1,8 +1,8 @@
 ---
 tests:
-  - Prompting-Home-Yq-Parallel:
+  Prompting-Home-Yq-Parallel:
     entrypoint: "tests/prompting/"
-  - Prompting-Home-Yq-Parallel-Cancellation:
+  Prompting-Home-Yq-Parallel-Cancellation:
     entrypoint: "tests/prompting/"
-  - Prompting-Home-Yq-Firefox-Parallel:
+  Prompting-Home-Yq-Firefox-Parallel:
     entrypoint: "tests/prompting/"

--- a/tests/prompting/plans/home-single.yaml
+++ b/tests/prompting/plans/home-single.yaml
@@ -1,3 +1,6 @@
 ---
-robot_files:
-  - "tests/prompting/prompting-home-firefox-download-single/prompting-home-firefox-download-single.robot"
+tests:
+  Prompting-Home-Firefox-Download-Single:
+    entrypoint: tests/prompting/
+    requirements:
+      tpm: true


### PR DESCRIPTION
Makes it easier to unmarshal in Go.