### PR TITLE
fix: tpm action api test

### DIFF
--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -616,6 +616,7 @@ Enter Firmware Settings
     Match Text    GRUB
     Type String    cfwsetup
     Keys Combo    Return
+    Match Text    Standard PC  60
 
 Toggle Secure Boot
     [Documentation]     Toggle Secure Boot in Firmware Settings

--- a/tests/desktop-installer/resolute/tpm-fde-action-api-secure-boot/tpm-fde-action-api-secure-boot.robot
+++ b/tests/desktop-installer/resolute/tpm-fde-action-api-secure-boot/tpm-fde-action-api-secure-boot.robot
@@ -184,7 +184,7 @@ Wait For TPM Install To Finish
 
 Wait For Reboot To Finish
     [Documentation]    Wait for the post-install reboot to finish
-    Wait For Reboot To Finish
+    Wait For Reboot To Finish  template=generic-resolute
 
 Wait For GIS Popup
     [Documentation]    Wait for the gnome-initial-setup popup


### PR DESCRIPTION
Two small fixes for the TPM/FDE action API test for the desktop installer:
* Wait until the firmware settings screen appears before pressing any buttons
* Use updated template (#81)
<img width="1035" height="723" alt="image" src="https://github.com/user-attachments/assets/8ac6f31d-1b61-49e8-a882-e729169c531c" />
