### PR TITLE
fix: remove wrong template from noble installer tests

### DIFF
--- a/tests/desktop-installer/noble/entire-disk-with-zfs/entire-disk-with-zfs.robot
+++ b/tests/desktop-installer/noble/entire-disk-with-zfs/entire-disk-with-zfs.robot
@@ -92,7 +92,7 @@ Stop Journal Monitor
 
 Wait For Reboot To Finish
     [Documentation]         Wait for the post-install reboot to finish
-    Wait For Reboot To Finish  template=generic-resolute
+    Wait For Reboot To Finish
 
 Wait For GIS Popup
     [Documentation]         Wait for the gnome-initial-setup popup

--- a/tests/desktop-installer/noble/entire-disk/entire-disk.robot
+++ b/tests/desktop-installer/noble/entire-disk/entire-disk.robot
@@ -92,7 +92,7 @@ Stop Journal Monitor
 
 Wait For Reboot To Finish
     [Documentation]         Wait for the post-install reboot to finish
-    Wait For Reboot To Finish  template=generic-resolute
+    Wait For Reboot To Finish
 
 Wait For GIS Popup
     [Documentation]         Wait for the gnome-initial-setup popup


### PR DESCRIPTION
I accidentally added the `generic-resolute` template parameter to noble installer tests in #81. This fixes it.