### PR TITLE
fix: allign snap-tpmctl tests with current implementation

### DIFF
--- a/common/common.resource
+++ b/common/common.resource
@@ -164,10 +164,10 @@ Answer Prompt
 
 System Reboot
     [Documentation]    Reboot the system and log in again
-    [Arguments]    ${with_prompt}=${False}    ${prompt}=""    ${input}=""
+    [Arguments]    ${prompt}=""    ${input}=""
     Run Simple Command    reboot
     BuiltIn.Sleep    60
-    IF    ${with_prompt}    Answer Prompt    ${prompt}    ${input}
+    IF    ${prompt} != ""    Answer Prompt    ${prompt}    ${input}
     Log In
     Open Terminal
     Run Sudo Command In Terminal    sudo echo
@@ -175,6 +175,7 @@ System Reboot
 Check No Match In Output
     [Documentation]    Run a command in terminal and check that the give output isn't present
     [Arguments]    ${cmd}    ${output}
-    Run Simple Command   ${cmd} | grep ${output}
-    Run Command In Terminal    echo $?
+    Run Simple Command    ${cmd} | grep ${output}
+    BuiltIn.Sleep    1
+    Run Simple Command    echo $?
     Match Text    1

--- a/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
+++ b/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
@@ -68,13 +68,14 @@ Regenerate An Existing Recovery Key
     Match Text    Recovery Key:
     Keys Combo    Return
 
-Replace Passphrase With Fail
-    [Documentation]    Fail to replace the default passphrase due incorrect passphrase
-    Run Command With Prompt    sudo snap-tpmctl replace-passphrase
-    Answer Prompt    current passphrase    ${NEW_PASSPHRASE}
-    Answer Prompt    new passphrase    ${NEW_PASSPHRASE}
-    Answer Prompt    new passphrase    ${NEW_PASSPHRASE}
-    Match Text    passphrase is incorrect
+# NOTE: decomment this after https://github.com/canonical/snapd/pull/16966 is merged in snapd
+# Replace Passphrase With Fail
+#    [Documentation]    Fail to replace the default passphrase due incorrect passphrase
+#    Run Command With Prompt    sudo snap-tpmctl replace-passphrase
+#    Answer Prompt    current passphrase    ${NEW_PASSPHRASE}
+#    Answer Prompt    new passphrase    ${NEW_PASSPHRASE}
+#    Answer Prompt    new passphrase    ${NEW_PASSPHRASE}
+#    Match Text    passphrase is incorrect
 
 Replace Passphrase
     [Documentation]    Replace the default passphrase

--- a/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
+++ b/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
@@ -33,7 +33,7 @@ Print Status
     [Documentation]    Print TPM/FDE status
     Open Terminal
     Run Command In Terminal    snap-tpmctl status
-    Match Text    INDETERMINATE
+    Match Text    ACTIVE
 
 List All Recovery Keys
     [Documentation]    List all recovery keys
@@ -45,13 +45,13 @@ Check Recovery Key
     [Documentation]    Check existing recovery key
     Run Command With Prompt    sudo snap-tpmctl check-recovery-key
     Answer Prompt    Enter recovery key:    ${RECOVERY_KEY}
-    Match Text    recovery key works
+    Match Text    Recovery key works
 
 Check Recovery Key With Fail
     [Documentation]    Check existing recovery key
     Run Command With Prompt    sudo snap-tpmctl check-recovery-key
     Answer Prompt    Enter recovery key:    ${FAKE_RECOVERY_KEY}
-    Match Text    recovery key doesn't work
+    Match Text    Recovery key does not work
 
 Create A New Recovery Key
     [Documentation]    Create a new recovery key

--- a/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
+++ b/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
@@ -28,13 +28,6 @@ Log In
 Install snap-tpmctl
     [Documentation]    Install the snap-tpmctl snap
     Install Snap Package    snap-tpmctl
-    Open Terminal
-    Run Sudo Command In Terminal    sudo snap connect snap-tpmctl:snapd-control
-    Run Command In Terminal    sudo snap connect snap-tpmctl:hardware-observe
-    Run Command In Terminal    sudo snap connect snap-tpmctl:mountctl
-    Run Command In Terminal    sudo snap connect snap-tpmctl:mount-observe
-    Run Command In Terminal    sudo snap connect snap-tpmctl:block-devices
-    Run Command In Terminal    sudo snap connect snap-tpmctl:dm-crypt
 
 Print Status
     [Documentation]    Print TPM/FDE status

--- a/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
+++ b/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
@@ -8,10 +8,10 @@ Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-wo
 
 
 *** Variables ***
-${Z}    ${CURDIR}
+${Z}                    ${CURDIR}
 
-${NEW_PASSPHRASE}    ubuntu2.
-${PIN}    123451234512345
+${NEW_PASSPHRASE}       ubuntu2.
+${PIN}                  123451234512345
 ${RECOVERY_KEY_NAME}    test-recovery-key
 ${FAKE_RECOVERY_KEY}    11111-22222-33333-44444-55555-12345-23451-34512
 
@@ -37,7 +37,7 @@ Print Status
 
 List All Recovery Keys
     [Documentation]    List all recovery keys
-    Run Command In Terminal    snap-tpmctl list-all
+    Run Sudo Command In Terminal    sudo snap-tpmctl list-all
     Match Text    default-recovery
     Match Text    passphrase
 
@@ -55,7 +55,7 @@ Check Recovery Key With Fail
 
 Create A New Recovery Key
     [Documentation]    Create a new recovery key
-    Run Command In Terminal    sudo snap-tpmctl create-recovery-key ${RECOVERY_KEY_NAME}
+    Run Simple Command    sudo snap-tpmctl create-recovery-key ${RECOVERY_KEY_NAME}
     Match Text    Recovery Key:
     Keys Combo    Return
     Run Command In Terminal    snap-tpmctl list-recovery-keys
@@ -64,7 +64,7 @@ Create A New Recovery Key
 
 Regenerate An Existing Recovery Key
     [Documentation]    Regenerate a recovery key
-    Run Command In Terminal    sudo snap-tpmctl regenerate-recovery-key ${RECOVERY_KEY_NAME}
+    Run Simple Command    sudo snap-tpmctl regenerate-recovery-key ${RECOVERY_KEY_NAME}
     Match Text    Recovery Key:
     Keys Combo    Return
 

--- a/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
+++ b/tests/snap-tpmctl/snap-tpmctl-cli/snap-tpmctl-cli.robot
@@ -32,12 +32,12 @@ Install snap-tpmctl
 Print Status
     [Documentation]    Print TPM/FDE status
     Open Terminal
-    Run Command In Terminal    snap-tpmctl status
+    Run Sudo Command In Terminal    sudo snap-tpmctl status
     Match Text    ACTIVE
 
 List All Recovery Keys
     [Documentation]    List all recovery keys
-    Run Sudo Command In Terminal    sudo snap-tpmctl list-all
+    Run Command In Terminal    snap-tpmctl list-all
     Match Text    default-recovery
     Match Text    passphrase
 

--- a/tests/snap-tpmctl/snap-tpmctl-mount/snap-tpmctl-mount.robot
+++ b/tests/snap-tpmctl/snap-tpmctl-mount/snap-tpmctl-mount.robot
@@ -8,7 +8,7 @@ Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-wo
 
 
 *** Variables ***
-${Z}    ${CURDIR}
+${Z}            ${CURDIR}
 
 ${DIRECTORY}    /media/my-vol
 
@@ -21,35 +21,36 @@ Log In
 Install snap-tpmctl
     [Documentation]    Install the snap-tpmctl snap
     Install Snap Package    snap-tpmctl
+
+Print Status
+    [Documentation]    Print TPM/FDE status
     Open Terminal
-    Run Sudo Command In Terminal    sudo snap connect snap-tpmctl:snapd-control
-    Run Command In Terminal    sudo snap connect snap-tpmctl:hardware-observe
-    Run Command In Terminal    sudo snap connect snap-tpmctl:mountctl
-    Run Command In Terminal    sudo snap connect snap-tpmctl:mount-observe
-    Run Command In Terminal    sudo snap connect snap-tpmctl:block-devices
-    Run Command In Terminal    sudo snap connect snap-tpmctl:dm-crypt
+    Run Sudo Command In Terminal    sudo snap-tpmctl status
+    Match Text    ACTIVE
 
 Mount LUKS Volume With Fail
     [Documentation]    Mount a LUKS volume portected with a passphrase
     Run Command With Prompt    sudo snap-tpmctl mount-volume ${DEVICE} test
-    Match Text    directory path must be a valid absolute path
+    Match Text    unable to create directory
 
 Mount LUKS Volume
     [Documentation]    Mount a LUKS volume portected with a passphrase
     Run Command With Prompt    sudo snap-tpmctl mount-volume ${DEVICE} ${DIRECTORY}
     Answer Prompt    Enter recovery key:    ${RECOVERY_KEY}
+    BuiltIn.Sleep    3
+    Run Simple Command    clear && lsblk | grep ${DIRECTORY}
     BuiltIn.Sleep    1
-    Run Command In Terminal    lsblk | grep ${DIRECTORY}
-    Match Text    crypt ${DIRECTORY}
+    Match Text    crypt ${DIRECTORY}    10
 
 Unmount LUKS Volume
     [Documentation]    Unmount a LUKS volume
     Run Command In Terminal    sudo snap-tpmctl unmount-volume ${DIRECTORY}
-    Run Command In Terminal    lsblk | grep ${DIRECTORY}
-    Run Command In Terminal    echo $?
+    Run Simple Command    clear && lsblk | grep ${DIRECTORY}
+    BuiltIn.Sleep    1
+    Run Simple Command    echo $?
     Match Text    1
 
 Unmount LUKS Volume With Fail
     [Documentation]    Unmount a LUKS volume
-    Run Command In Terminal    sudo snap-tpmctl unmount-volume ${DIRECTORY}
-    Match Text    ERROR systemd-cryptsetup failed with:
+    Run Simple Command   clear && sudo snap-tpmctl unmount-volume ${DIRECTORY}
+    Match Text    the mount point doesn't exist

--- a/tests/snap-tpmctl/snap-tpmctl.resource
+++ b/tests/snap-tpmctl/snap-tpmctl.resource
@@ -1,2 +1,8 @@
 *** Settings ***
 Documentation       Shared resources for application testing
+
+Resource            ${Y}/common/common.resource
+
+
+*** Variables ***
+${Y}    ${CURDIR}


### PR DESCRIPTION
This allign tests with the current `snap-tpmctl` implementation, fixing error matching and behaviour