### PR TITLE
feat: add installer tests for stonking

### DIFF
--- a/tests/desktop-installer/generic-stonking
+++ b/tests/desktop-installer/generic-stonking
@@ -1,0 +1,1 @@
+generic-resolute

--- a/tests/desktop-installer/stonking/entire-disk-with-lvm-and-encryption/entire-disk-with-lvm-and-encryption.robot
+++ b/tests/desktop-installer/stonking/entire-disk-with-lvm-and-encryption/entire-disk-with-lvm-and-encryption.robot
@@ -1,0 +1,123 @@
+*** Settings ***
+Documentation         Perform an LVM+encryption installation
+Resource        kvm.resource
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+Resource    ${CURDIR}/../../installer.resource
+
+
+*** Test Cases ***
+Grub Menu
+    [Documentation]         Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]         Workaround LP: #2112383
+    Ensure Not Unfocused After Boot  template=generic-stonking
+
+Install OpenSSHServer
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer   livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket     livesession=True
+
+Set Live Session User Password
+    [Documentation]         Set password of the live session user to 'ubuntu'
+    Set Live Session User Password       ubuntu  ubuntu
+
+Start Journal Monitor
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]         Go through language slide
+    Select Language  template=generic-stonking
+
+A11y Slide
+    [Documentation]         Go through a11y slide
+    A11y Slide  template=generic-stonking
+
+Keyboard Layout
+    [Documentation]         Use default keyboard layout
+    Keyboard Layout  template=generic-stonking
+
+Internet Connection
+    [Documentation]         Go through internet connection slide
+    Internet Connection  template=generic-stonking
+
+Skip Installer Update
+    [Documentation]         Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]         Go through try or install slide
+    Try Or Install  template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]         Go through interactive vs automated slide
+    Interactive vs Automated  template=generic-stonking
+
+Default vs Extended
+    [Documentation]         Go through default vs extended slide
+    Default vs Extended  template=generic-stonking
+
+Proprietary Software
+    [Documentation]         Go through proprietary software slide
+    Proprietary Software  template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]         Go through proprietary software slide
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]         Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu  template=generic-stonking
+
+Encryption And File System Lvm Encryption
+    [Documentation]         Select lvm and encryption from the encryption menu
+    Encryption And File System Lvm Encryption
+
+Disk Passphrase Setup Questing Onwards
+    [Documentation]         Set up a passphrase for encrypted lvm volumes
+    Disk Passphrase Setup Questing Onwards
+
+Create Account
+    [Documentation]         Create a user on the installed system
+    Create Account  template=generic-stonking
+
+Select Timezone
+    [Documentation]         Choose a timezone
+    Select Timezone  template=generic-stonking
+
+Review Installation
+    [Documentation]         Review installation slide
+    Review Installation  template=generic-stonking
+
+Wait For Install To Finish
+    [Documentation]         Wait for the installation to finish
+    Wait For Install To Finish
+
+Stop Journal Monitor
+    [Documentation]         Stop monitoring the system journal
+    JournalMonitor.Stop
+
+Wait For LVM Encrypted Reboot To Finish
+    [Documentation]         Wait for the post-install reboot to finish
+    Wait For LVM Encrypted Reboot To Finish
+
+Wait For GIS Popup
+    [Documentation]         Wait for the gnome-initial-setup popup
+    Wait For GIS Popup
+
+Install OpenSSHServer In Installed System
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer
+
+Start sshd VSOCK socket In Installed System
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket
+
+Start Journal Monitor In Installed System
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start

--- a/tests/desktop-installer/stonking/entire-disk-with-zfs-plus-encryption/entire-disk-with-zfs-plus-encryption.robot
+++ b/tests/desktop-installer/stonking/entire-disk-with-zfs-plus-encryption/entire-disk-with-zfs-plus-encryption.robot
@@ -1,0 +1,123 @@
+*** Settings ***
+Documentation         Encrypted zfs installation
+Resource        kvm.resource
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+Resource    ${CURDIR}/../../installer.resource
+
+
+*** Test Cases ***
+Grub Menu
+    [Documentation]         Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]         Workaround LP: #2112383
+    Ensure Not Unfocused After Boot  template=generic-stonking
+
+Install OpenSSHServer
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer   livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket     livesession=True
+
+Set Live Session User Password
+    [Documentation]         Set password of the live session user to 'ubuntu'
+    Set Live Session User Password       ubuntu  ubuntu
+
+Start Journal Monitor
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]         Go through language slide
+    Select Language  template=generic-stonking
+
+A11y Slide
+    [Documentation]         Go through a11y slide
+    A11y Slide  template=generic-stonking
+
+Keyboard Layout
+    [Documentation]         Use default keyboard layout
+    Keyboard Layout  template=generic-stonking
+
+Internet Connection
+    [Documentation]         Go through internet connection slide
+    Internet Connection  template=generic-stonking
+
+Skip Installer Update
+    [Documentation]         Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]         Go through try or install slide
+    Try Or Install  template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]         Go through interactive vs automated slide
+    Interactive vs Automated  template=generic-stonking
+
+Default vs Extended
+    [Documentation]         Go through default vs extended slide
+    Default vs Extended  template=generic-stonking
+
+Proprietary Software
+    [Documentation]         Go through proprietary software slide
+    Proprietary Software  template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]         Select erase disk and reinstall
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]         Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu  template=generic-stonking
+
+Encryption And File System Zfs Encryption
+    [Documentation]         Select zfs encryption from the encryption menu
+    Encryption And File System Zfs Encryption
+
+Disk Passphrase Setup Questing Onwards
+    [Documentation]         Set up a passphrase for the zfs encrypted volumes
+    Disk Passphrase Setup Questing Onwards
+
+Create Account
+    [Documentation]         Create a user on the installed system
+    Create Account  template=generic-stonking
+
+Select Timezone
+    [Documentation]         Choose a timezone
+    Select Timezone  template=generic-stonking
+
+Review Installation
+    [Documentation]         Review installation slide
+    Review Installation  template=generic-stonking
+
+Wait For Install To Finish
+    [Documentation]         Wait for the installation to finish
+    Wait For Install To Finish
+
+Stop Journal Monitor
+    [Documentation]         Stop monitoring the system journal
+    JournalMonitor.Stop
+
+Wait For ZFS Encrypted Reboot To Finish
+    [Documentation]         Wait for the post-install reboot to finish, and enter passphrase on reboot
+    Wait For ZFS Encrypted Reboot To Finish
+
+Wait For GIS Popup
+    [Documentation]         Wait for the gnome-initial-setup popup
+    Wait For GIS Popup
+
+Install OpenSSHServer In Installed System
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer
+
+Start sshd VSOCK socket In Installed System
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket
+
+Start Journal Monitor In Installed System
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start

--- a/tests/desktop-installer/stonking/entire-disk-with-zfs/entire-disk-with-zfs.robot
+++ b/tests/desktop-installer/stonking/entire-disk-with-zfs/entire-disk-with-zfs.robot
@@ -1,0 +1,119 @@
+*** Settings ***
+Documentation         Do an entire disk installation with zfs
+Resource        kvm.resource
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+Resource    ${CURDIR}/../../installer.resource
+
+
+*** Test Cases ***
+Grub Menu
+    [Documentation]         Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]         Workaround LP: #2112383
+    Ensure Not Unfocused After Boot  template=generic-stonking
+
+Install OpenSSHServer
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer   livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket     livesession=True
+
+Set Live Session User Password
+    [Documentation]         Set password of the live session user to 'ubuntu'
+    Set Live Session User Password       ubuntu  ubuntu
+
+Start Journal Monitor
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]         Go through language slide
+    Select Language  template=generic-stonking
+
+A11y Slide
+    [Documentation]         Go through a11y slide
+    A11y Slide  template=generic-stonking
+
+Keyboard Layout
+    [Documentation]         Use default keyboard layout
+    Keyboard Layout  template=generic-stonking
+
+Internet Connection
+    [Documentation]         Go through internet connection slide
+    Internet Connection  template=generic-stonking
+
+Skip Installer Update
+    [Documentation]         Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]         Go through try or install slide
+    Try Or Install  template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]         Go through interactive vs automated slide
+    Interactive vs Automated  template=generic-stonking
+
+Default vs Extended
+    [Documentation]         Go through default vs extended slide
+    Default vs Extended  template=generic-stonking
+
+Proprietary Software
+    [Documentation]         Go through proprietary software slide
+    Proprietary Software  template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]         Select erase disk and reinstall
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]         Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu  template=generic-stonking
+
+Encryption And File System Zfs No Encryption
+    [Documentation]         Select zfs encryption from the encryption menu
+    Encryption And File System Zfs No Encryption
+
+Create Account
+    [Documentation]         Create a user on the installed system
+    Create Account  template=generic-stonking
+
+Select Timezone
+    [Documentation]         Choose a timezone
+    Select Timezone  template=generic-stonking
+
+Review Installation
+    [Documentation]         Review installation slide
+    Review Installation  template=generic-stonking
+
+Wait For Install To Finish
+    [Documentation]         Wait for the installation to finish
+    Wait For Install To Finish
+
+Stop Journal Monitor
+    [Documentation]         Stop monitoring the system journal
+    JournalMonitor.Stop
+
+Wait For Reboot To Finish
+    [Documentation]         Wait for the reboot to finish
+    Wait For Reboot To Finish  template=generic-stonking
+
+Wait For GIS Popup
+    [Documentation]         Wait for the gnome-initial-setup popup
+    Wait For GIS Popup
+
+Install OpenSSHServer In Installed System
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer
+
+Start sshd VSOCK socket In Installed System
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket
+
+Start Journal Monitor In Installed System
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start

--- a/tests/desktop-installer/stonking/entire-disk/entire-disk.robot
+++ b/tests/desktop-installer/stonking/entire-disk/entire-disk.robot
@@ -1,0 +1,119 @@
+*** Settings ***
+Documentation         Normal, entire disk install
+Resource        kvm.resource
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+Resource    ${CURDIR}/../../installer.resource
+
+
+*** Test Cases ***
+Grub Menu
+    [Documentation]         Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]         Workaround LP: #2112383
+    Ensure Not Unfocused After Boot  template=generic-stonking
+
+Install OpenSSHServer
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer   livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket     livesession=True
+
+Set Live Session User Password
+    [Documentation]         Set password of the live session user to 'ubuntu'
+    Set Live Session User Password       ubuntu  ubuntu
+
+Start Journal Monitor
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]         Go through language slide
+    Select Language  template=generic-stonking
+
+A11y Slide
+    [Documentation]         Go through a11y slide
+    A11y Slide  template=generic-stonking
+
+Keyboard Layout
+    [Documentation]         Use default keyboard layout
+    Keyboard Layout  template=generic-stonking
+
+Internet Connection
+    [Documentation]         Go through internet connection slide
+    Internet Connection  template=generic-stonking
+
+Skip Installer Update
+    [Documentation]         Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]         Go through try or install slide
+    Try Or Install  template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]         Go through interactive vs automated slide
+    Interactive vs Automated  template=generic-stonking
+
+Default vs Extended
+    [Documentation]         Go through default vs extended slide
+    Default vs Extended  template=generic-stonking
+
+Proprietary Software
+    [Documentation]         Go through proprietary software slide
+    Proprietary Software  template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]         Select erase disk and reinstall
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]         Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu  template=generic-stonking
+
+Encryption And File System No Encryption
+    [Documentation]         Select no encryption
+    Encryption And File System No Encryption
+
+Create Account
+    [Documentation]         Create a user on the installed system
+    Create Account  template=generic-stonking
+
+Select Timezone
+    [Documentation]         Choose a timezone
+    Select Timezone  template=generic-stonking
+
+Review Installation
+    [Documentation]         Review installation slide
+    Review Installation  template=generic-stonking
+
+Wait For Install To Finish
+    [Documentation]         Wait for the installation to finish
+    Wait For Install To Finish
+
+Stop Journal Monitor
+    [Documentation]         Stop monitoring the system journal
+    JournalMonitor.Stop
+
+Wait For Reboot To Finish
+    [Documentation]         Wait for the reboot post-install
+    Wait For Reboot To Finish  template=generic-stonking
+
+Wait For GIS Popup
+    [Documentation]         Wait for the gnome-initial-setup popup
+    Wait For GIS Popup
+
+Install OpenSSHServer In Installed System
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer
+
+Start sshd VSOCK socket In Installed System
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket
+
+Start Journal Monitor In Installed System
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start

--- a/tests/desktop-installer/stonking/tpm-fde-action-api-secure-boot/tpm-fde-action-api-secure-boot.robot
+++ b/tests/desktop-installer/stonking/tpm-fde-action-api-secure-boot/tpm-fde-action-api-secure-boot.robot
@@ -1,0 +1,203 @@
+*** Settings ***
+Documentation       TPM FDE installation with Secure Boot disabled
+
+Resource            kvm.resource
+Resource            ${CURDIR}/../../installer.resource
+
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+
+
+*** Test Cases ***
+Disable Secure Boot
+    [Documentation]    Disable Secure Boot in the firmware settings
+    Disable Secure Boot
+
+Grub Menu
+    [Documentation]    Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]    Workaround LP: #2112383
+    Ensure Not Unfocused After Boot
+
+Install OpenSSHServer
+    [Documentation]    Install openssh-server to collect logs
+    Install OpenSSHServer    livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]    Start sshd-vsock.socket
+    Start sshd VSOCK socket    livesession=True
+
+Set Live Session User Password
+    [Documentation]    Set password of the live session user to 'ubuntu'
+    Set Live Session User Password    ubuntu    ubuntu
+
+Start Journal Monitor
+    [Documentation]    Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]    Go through language slide
+    Select Language    template=generic-stonking
+
+A11y Slide
+    [Documentation]    Go through a11y slide
+    A11y Slide    template=generic-stonking
+
+Keyboard Layout
+    [Documentation]    Use default keyboard layout
+    Keyboard Layout    template=generic-stonking
+
+Internet Connection
+    [Documentation]    Go through internet connection slide
+    Internet Connection    template=generic-stonking
+
+Skip Installer Update
+    [Documentation]    Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]    Go through try or install slide
+    Try Or Install    template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]    Go through interactive vs automated slide
+    Interactive vs Automated    template=generic-stonking
+
+Default vs Extended
+    [Documentation]    Go through default vs extended slide
+    Default vs Extended    template=generic-stonking
+
+Proprietary Software
+    [Documentation]    Go through proprietary software slide
+    Proprietary Software    template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]    Select erase disk and reinstall
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]    Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu    template=generic-stonking
+
+Encryption And File System Tpm Encryption
+    [Documentation]    Select tpm encryption from the encryption menu
+    Encryption And File System Tpm Encryption
+
+Encryption And File System Tpm Not Available
+    [Documentation]    Ensure that the TPM FDE encryption option is greyed out, and not selectable
+    Encryption And File System Tpm Not Available
+
+TPM Action Enable Secure Boot Manually
+    [Documentation]    Enable Secure Boot Manually when prompted on the TPM action page
+    TPM Action Enable Secure Boot Manually
+
+# go thorugh the installer again with secure boot enabled
+
+Grub Menu 2
+    [Documentation]    Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot 2
+    [Documentation]    Workaround LP: #2112383
+    Ensure Not Unfocused After Boot
+
+Install OpenSSHServer 2
+    [Documentation]    Install openssh-server to collect logs
+    Install OpenSSHServer    livesession=True
+
+Start sshd VSOCK socket 2
+    [Documentation]    Start sshd-vsock.socket
+    Start sshd VSOCK socket    livesession=True
+
+Set Live Session User Password 2
+    [Documentation]    Set password of the live session user to 'ubuntu'
+    Set Live Session User Password    ubuntu    ubuntu
+
+Start Journal Monitor 2
+    [Documentation]    Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide 2
+    [Documentation]    Go through language slide
+    Select Language    template=generic-stonking
+
+A11y Slide 2
+    [Documentation]    Go through a11y slide
+    A11y Slide    template=generic-stonking
+
+Keyboard Layout 2
+    [Documentation]    Use default keyboard layout
+    Keyboard Layout    template=generic-stonking
+
+Internet Connection 2
+    [Documentation]    Go through internet connection slide
+    Internet Connection    template=generic-stonking
+
+Skip Installer Update 2
+    [Documentation]    Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install 2
+    [Documentation]    Go through try or install slide
+    Try Or Install    template=generic-stonking
+
+Interactive vs Automated 2
+    [Documentation]    Go through interactive vs automated slide
+    Interactive vs Automated    template=generic-stonking
+
+Default vs Extended 2
+    [Documentation]    Go through default vs extended slide
+    Default vs Extended    template=generic-stonking
+
+Proprietary Software 2
+    [Documentation]    Go through proprietary software slide
+    Proprietary Software    template=generic-stonking
+
+Select Erase Disk and Reinstall 2
+    [Documentation]    Select erase disk and reinstall
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu 2
+    [Documentation]    Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu    template=generic-stonking
+
+Encryption And File System Tpm Encryption 2
+    [Documentation]    Select tpm encryption from the encryption menu
+    Encryption And File System Tpm Encryption
+
+Create Account
+    [Documentation]    Create a user on the installed system
+    Create Account    template=generic-stonking
+
+Select Timezone
+    [Documentation]    Choose a timezone
+    Select Timezone    template=generic-stonking
+
+Review Installation
+    [Documentation]    Review installation slide
+    Review Installation    template=generic-stonking
+
+Wait For TPM Install To Finish
+    [Documentation]    Wait for the installation to finish
+    Wait For TPM Install To Finish
+
+Wait For Reboot To Finish
+    [Documentation]    Wait for the post-install reboot to finish
+    Wait For Reboot To Finish  template=generic-stonking
+
+Wait For GIS Popup
+    [Documentation]    Wait for the gnome-initial-setup popup
+    Wait For GIS Popup
+
+Install OpenSSHServer In Installed System
+    [Documentation]    Install openssh-server to collect logs
+    Install OpenSSHServer
+
+Start sshd VSOCK socket In Installed System
+    [Documentation]    Start sshd-vsock.socket
+    Start sshd VSOCK socket
+
+Open Firmware Updater
+    [Documentation]    Make sure the firmware-updater snap opens
+    Open Firmware Updater

--- a/tests/desktop-installer/stonking/tpm-fde-no-passphrase/tpm-fde-no-passphrase.robot
+++ b/tests/desktop-installer/stonking/tpm-fde-no-passphrase/tpm-fde-no-passphrase.robot
@@ -1,0 +1,123 @@
+*** Settings ***
+Documentation         TPM FDE installation with no pin or passphrase
+Resource        kvm.resource
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+Resource    ${CURDIR}/../../installer.resource
+
+
+*** Test Cases ***
+Grub Menu
+    [Documentation]         Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]         Workaround LP: #2112383
+    Ensure Not Unfocused After Boot  template=generic-stonking
+
+Install OpenSSHServer
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer   livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket     livesession=True
+
+Set Live Session User Password
+    [Documentation]         Set password of the live session user to 'ubuntu'
+    Set Live Session User Password       ubuntu  ubuntu
+
+Start Journal Monitor
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]         Go through language slide
+    Select Language  template=generic-stonking
+
+A11y Slide
+    [Documentation]         Go through a11y slide
+    A11y Slide  template=generic-stonking
+
+Keyboard Layout
+    [Documentation]         Use default keyboard layout
+    Keyboard Layout  template=generic-stonking
+
+Internet Connection
+    [Documentation]         Go through internet connection slide
+    Internet Connection  template=generic-stonking
+
+Skip Installer Update
+    [Documentation]         Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]         Go through try or install slide
+    Try Or Install  template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]         Go through interactive vs automated slide
+    Interactive vs Automated  template=generic-stonking
+
+Default vs Extended
+    [Documentation]         Go through default vs extended slide
+    Default vs Extended  template=generic-stonking
+
+Proprietary Software
+    [Documentation]         Go through proprietary software slide
+    Proprietary Software  template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]         Select erase disk and reinstall
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]         Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu  template=generic-stonking
+
+Encryption And File System Tpm Encryption
+    [Documentation]         Select tpm encryption from the encryption menu
+    Encryption And File System Tpm Encryption
+
+Create Account
+    [Documentation]         Create a user on the installed system
+    Create Account  template=generic-stonking
+
+Select Timezone
+    [Documentation]         Choose a timezone
+    Select Timezone  template=generic-stonking
+
+Review Installation
+    [Documentation]         Review installation slide
+    Review Installation  template=generic-stonking
+
+Wait For TPM Install To Finish
+    [Documentation]         Wait for the installation to finish
+    Wait For TPM Install To Finish
+
+Stop Journal Monitor
+    [Documentation]         Stop monitoring the system journal
+    JournalMonitor.Stop
+
+Wait For Reboot To Finish
+    [Documentation]         Wait for the post-install reboot to finish
+    Wait For Reboot To Finish  template=generic-stonking
+
+Wait For GIS Popup
+    [Documentation]         Wait for the gnome-initial-setup popup
+    Wait For GIS Popup
+
+Install OpenSSHServer In Installed System
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer
+
+Start sshd VSOCK socket In Installed System
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket
+
+Open Firmware Updater
+    [Documentation]         Make sure the firmware-updater snap opens
+    Open Firmware Updater
+
+Start Journal Monitor In Installed System
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start

--- a/tests/desktop-installer/stonking/tpm-fde-not-available/tpm-fde-not-available.robot
+++ b/tests/desktop-installer/stonking/tpm-fde-not-available/tpm-fde-not-available.robot
@@ -1,0 +1,83 @@
+*** Settings ***
+Documentation         Ensure that TPM isn't offered by the installer on non-tpm systems
+Resource        kvm.resource
+Test Tags           robot:exit-on-failure    # robocop: off=tag-with-reserved-word
+Resource    ${CURDIR}/../../installer.resource
+
+
+*** Test Cases ***
+Grub Menu
+    [Documentation]         Go through grub menu, if present
+    Grub Menu
+
+Ensure Not Unfocused After Boot
+    [Documentation]         Workaround LP: #2112383
+    Ensure Not Unfocused After Boot  template=generic-stonking
+
+Install OpenSSHServer
+    [Documentation]         Install openssh-server to collect logs
+    Install OpenSSHServer   livesession=True
+
+Start sshd VSOCK socket
+    [Documentation]         Start sshd-vsock.socket
+    Start sshd VSOCK socket     livesession=True
+
+Set Live Session User Password
+    [Documentation]         Set password of the live session user to 'ubuntu'
+    Set Live Session User Password       ubuntu  ubuntu
+
+Start Journal Monitor
+    [Documentation]         Start monitoring the system journal
+    JournalMonitor.Start
+
+Language Slide
+    [Documentation]         Go through language slide
+    Select Language  template=generic-stonking
+
+A11y Slide
+    [Documentation]         Go through a11y slide
+    A11y Slide  template=generic-stonking
+
+Keyboard Layout
+    [Documentation]         Use default keyboard layout
+    Keyboard Layout  template=generic-stonking
+
+Internet Connection
+    [Documentation]         Go through internet connection slide
+    Internet Connection  template=generic-stonking
+
+Skip Installer Update
+    [Documentation]         Skip installer update, if present
+    Skip Installer Update
+
+Try Or Install
+    [Documentation]         Go through try or install slide
+    Try Or Install  template=generic-stonking
+
+Interactive vs Automated
+    [Documentation]         Go through interactive vs automated slide
+    Interactive vs Automated  template=generic-stonking
+
+Default vs Extended
+    [Documentation]         Go through default vs extended slide
+    Default vs Extended  template=generic-stonking
+
+Proprietary Software
+    [Documentation]         Go through proprietary software slide
+    Proprietary Software  template=generic-stonking
+
+Select Erase Disk and Reinstall
+    [Documentation]         Go through proprietary software slide
+    Select Erase Disk and Reinstall
+
+Choose Where to Install Ubuntu
+    [Documentation]         Go through slide showing various disks, if present
+    Choose Where to Install Ubuntu  template=generic-stonking
+
+Encryption And File System Tpm Encryption
+    [Documentation]         Select tpm encryption from the encryption menu
+    Encryption And File System Tpm Encryption
+
+Encryption And File System Tpm Not Available
+    [Documentation]         Ensure that the TPM FDE encryption option is greyed out, and not selectable
+    Encryption And File System Tpm Not Available


### PR DESCRIPTION
This adds a desktop installer test suite for stonking, which is currently identical to resolute. We'll continually evolve and hopefully refactor it during the development cycle. At the same time we want to keep the tests for noble and resolute untouched, unless we need to adapt them due to feature backports.