### PR TITLE
installer: use built-in keyword to restart stream during reboot

### DIFF
--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -354,7 +354,7 @@ Entire Disk With ZFS
     EzClick
 
 Restart Stream And Wait For Login
-    [Documentation]         Restart stream and wait for the login screen
+    [Documentation]         Restart stream and check for the login screen (single attempt; use Wait Until Keyword Succeeds to retry)
     [Arguments]     ${template}=generic
     Restart Video Input
     Match    ${T}/${template}/login-prompt.png    15

--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -366,7 +366,7 @@ Wait For Reboot To Finish
     Match Text       Please remove        120
     Keys Combo    ${combo}
 
-    Wait Until Keyword Succeeds    1800 sec   1    Restart Stream And Wait For Login    ${template}
+    Wait Until Keyword Succeeds    1800 sec    1 sec    Restart Stream And Wait For Login    ${template}
     Move Pointer To ${T}/${template}/login-prompt.png
     EzClick
 

--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -356,13 +356,8 @@ Entire Disk With ZFS
 Restart Stream And Wait For Login
     [Documentation]         Restart stream and wait for the login screen
     [Arguments]     ${template}=generic
-    FOR    ${_}    IN RANGE    120
-        Restart Video Input
-        ${match}                Run Keyword And Return Status
-        ...                     Match       ${T}/${template}/login-prompt.png       15
-        IF    ${match}    BREAK
-    END
-    IF    not ${match}    Fail    No match found
+    Restart Video Input
+    Match    ${T}/${template}/login-prompt.png    15
 
 Wait For Reboot To Finish
     [Documentation]    Login Prompt
@@ -371,7 +366,7 @@ Wait For Reboot To Finish
     Match Text       Please remove        120
     Keys Combo    ${combo}
 
-    Restart Stream And Wait For Login  template=${template}
+    Wait Until Keyword Succeeds    1800 sec   1    Restart Stream And Wait For Login    ${template}
     Move Pointer To ${T}/${template}/login-prompt.png
     EzClick
 


### PR DESCRIPTION
This removes the custom for loop used to restart the video input during a restart. The built-in keyword has the benefit of using a timeout between retries, allowing the VNC server to restart during a reboot. This is needed for the new libvirt-based runner to perform the post-install reboot where the cdrom is removed manually.