### PR TITLE
installer: ignore TPM/FDE error in stonking

### DIFF
--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -646,3 +646,11 @@ TPM Action Enable Secure Boot Manually
     EzClick
     Match Text  Device Manager  180
     Toggle Secure Boot
+
+TPM Action Running In VM Ignore And Continue
+    [Documentation]     Choose 'Ignore and continue' when secboot complains that the current environment is a VM.
+    Match Text  "The current environment is a virtual machine"
+    Move Pointer To "Solution: Ignore"
+    EzClick
+    Move Pointer To "Ignore and continue"
+    EzClick

--- a/tests/desktop-installer/stonking/tpm-fde-action-api-secure-boot/tpm-fde-action-api-secure-boot.robot
+++ b/tests/desktop-installer/stonking/tpm-fde-action-api-secure-boot/tpm-fde-action-api-secure-boot.robot
@@ -84,6 +84,10 @@ Encryption And File System Tpm Encryption
     [Documentation]    Select tpm encryption from the encryption menu
     Encryption And File System Tpm Encryption
 
+TPM Action Running In VM Ignore And Continue
+    [Documentation]     Choose 'Ignore and continue' when secboot complains that the current environment is a VM.
+    TPM Action Running In VM Ignore And Continue
+
 Encryption And File System Tpm Not Available
     [Documentation]    Ensure that the TPM FDE encryption option is greyed out, and not selectable
     Encryption And File System Tpm Not Available
@@ -165,6 +169,10 @@ Choose Where to Install Ubuntu 2
 Encryption And File System Tpm Encryption 2
     [Documentation]    Select tpm encryption from the encryption menu
     Encryption And File System Tpm Encryption
+
+TPM Action Running In VM Ignore And Continue 2
+    [Documentation]     Choose 'Ignore and continue' when secboot complains that the current environment is a VM.
+    TPM Action Running In VM Ignore And Continue
 
 Create Account
     [Documentation]    Create a user on the installed system

--- a/tests/desktop-installer/stonking/tpm-fde-no-passphrase/tpm-fde-no-passphrase.robot
+++ b/tests/desktop-installer/stonking/tpm-fde-no-passphrase/tpm-fde-no-passphrase.robot
@@ -78,6 +78,10 @@ Encryption And File System Tpm Encryption
     [Documentation]         Select tpm encryption from the encryption menu
     Encryption And File System Tpm Encryption
 
+TPM Action Running In VM Ignore And Continue
+    [Documentation]     Choose 'Ignore and continue' when secboot complains that the current environment is a VM.
+    TPM Action Running In VM Ignore And Continue
+
 Create Account
     [Documentation]         Create a user on the installed system
     Create Account  template=generic-stonking


### PR DESCRIPTION
snapd now correctly detects a VM environement and provides a corresponding error via the actions API. See https://github.com/canonical/snapd/pull/16620

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/94c1500b-a199-4332-8d4e-835b6916bb84" />
