### PR TITLE
runner: persist recovery key metadata for image runs

### DIFF
--- a/runner/tests/test_cli.py
+++ b/runner/tests/test_cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from ubuntu_gui_testing_runner.cli import parse_args
-from ubuntu_gui_testing_runner.defaults import (
+from ubuntu_gui_testing_runner.constants import (
     DEFAULT_ARTIFACTS_DIR,
     DEFAULT_CONNECTION_URI,
     DEFAULT_POOL_NAME,

--- a/runner/tests/test_image_runner.py
+++ b/runner/tests/test_image_runner.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from textwrap import dedent
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import libvirt  # type: ignore[import-untyped]
 import pytest
@@ -54,6 +55,50 @@ SOURCE_DOMAIN_XML_NO_NVRAM = dedent("""\
         </disk>
       </devices>
     </domain>
+""")
+
+SOURCE_DOMAIN_XML_WITH_RECOVERY_KEY = dedent("""\
+        <domain type="kvm">
+            <name>source</name>
+            <uuid>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</uuid>
+            <metadata>
+                <ugt:ugt xmlns:ugt="https://canonical.com/ubuntu-gui-testing">
+                    <ugt:recovery-key>12345-67890-11111-22222-33333-44444-55555-66666</ugt:recovery-key>
+                </ugt:ugt>
+            </metadata>
+            <os firmware="efi">
+                <type arch="x86_64" machine="q35">hvm</type>
+                <nvram>/pool/source-VARS.fd</nvram>
+            </os>
+            <devices>
+                <disk type="file" device="disk">
+                    <source file="/pool/source.qcow2"/>
+                    <target dev="vda" bus="virtio"/>
+                </disk>
+            </devices>
+        </domain>
+""")
+
+SOURCE_DOMAIN_XML_WITH_EMPTY_RECOVERY_KEY = dedent("""\
+        <domain type="kvm">
+            <name>source</name>
+            <uuid>aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee</uuid>
+            <metadata>
+                <ugt:ugt xmlns:ugt="https://canonical.com/ubuntu-gui-testing">
+                    <ugt:recovery-key>   </ugt:recovery-key>
+                </ugt:ugt>
+            </metadata>
+            <os firmware="efi">
+                <type arch="x86_64" machine="q35">hvm</type>
+                <nvram>/pool/source-VARS.fd</nvram>
+            </os>
+            <devices>
+                <disk type="file" device="disk">
+                    <source file="/pool/source.qcow2"/>
+                    <target dev="vda" bus="virtio"/>
+                </disk>
+            </devices>
+        </domain>
 """)
 
 
@@ -227,5 +272,134 @@ def test_skips_tpm_copy_when_source_has_no_tpm_state(tmp_path: Path) -> None:
             # Should not raise; TPM copy is simply skipped
             dest_tpm_dir = swtpm_dir / "11111111-2222-3333-4444-555555555555"
             assert not dest_tpm_dir.exists()
+        finally:
+            runner.close()
+
+
+def test_extracts_recovery_key_from_source_metadata(tmp_path: Path) -> None:
+    nvram_source = tmp_path / "source-VARS.fd"
+    nvram_source.write_bytes(b"nvram-data")
+
+    source_xml = SOURCE_DOMAIN_XML_WITH_RECOVERY_KEY.replace(
+        "/pool/source-VARS.fd", str(nvram_source)
+    )
+    conn = _make_conn(source_xml=source_xml)
+
+    pool_dir = tmp_path / "pool"
+    pool_dir.mkdir()
+
+    with patch("libvirt.open", return_value=conn):
+        runner = LibvirtImageRunner(
+            source_domain="source",
+            suite_name="test",
+            test_name="basic",
+            pool_dir=pool_dir,
+        )
+        try:
+            assert (
+                runner.recovery_key == "12345-67890-11111-22222-33333-44444-55555-66666"
+            )
+        finally:
+            runner.close()
+
+
+def test_run_yarf_passes_recovery_key_variable_when_present(tmp_path: Path) -> None:
+    nvram_source = tmp_path / "source-VARS.fd"
+    nvram_source.write_bytes(b"nvram-data")
+
+    source_xml = SOURCE_DOMAIN_XML_WITH_RECOVERY_KEY.replace(
+        "/pool/source-VARS.fd", str(nvram_source)
+    )
+    conn = _make_conn(source_xml=source_xml)
+
+    pool_dir = tmp_path / "pool"
+    pool_dir.mkdir()
+
+    with patch("libvirt.open", return_value=conn):
+        runner = LibvirtImageRunner(
+            source_domain="source",
+            suite_name="test",
+            test_name="basic",
+            pool_dir=pool_dir,
+        )
+        try:
+            mock_process = AsyncMock()
+            mock_process.wait = AsyncMock(return_value=0)
+            mock_process.returncode = 0
+            with patch.object(
+                runner, "_spawn_yarf", return_value=mock_process
+            ) as spawn:
+                asyncio.run(runner._run_yarf("suite", "test", 3, 5901))
+
+            spawn.assert_called_once_with(
+                "suite",
+                "test",
+                5901,
+                robot_variables={
+                    "CID": "3",
+                    "RECOVERY_KEY": "12345-67890-11111-22222-33333-44444-55555-66666",
+                },
+            )
+        finally:
+            runner.close()
+
+
+def test_logs_when_recovery_key_metadata_missing(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    nvram_source = tmp_path / "source-VARS.fd"
+    nvram_source.write_bytes(b"nvram-data")
+
+    source_xml = SOURCE_DOMAIN_XML.replace("/pool/source-VARS.fd", str(nvram_source))
+    conn = _make_conn(source_xml=source_xml)
+
+    pool_dir = tmp_path / "pool"
+    pool_dir.mkdir()
+
+    with patch("libvirt.open", return_value=conn), caplog.at_level("INFO"):
+        runner = LibvirtImageRunner(
+            source_domain="source",
+            suite_name="test",
+            test_name="basic",
+            pool_dir=pool_dir,
+        )
+        try:
+            assert runner.recovery_key is None
+            assert (
+                "No metadata block found in source domain 'source' XML" in caplog.text
+            )
+        finally:
+            runner.close()
+
+
+def test_logs_when_recovery_key_metadata_empty(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    nvram_source = tmp_path / "source-VARS.fd"
+    nvram_source.write_bytes(b"nvram-data")
+
+    source_xml = SOURCE_DOMAIN_XML_WITH_EMPTY_RECOVERY_KEY.replace(
+        "/pool/source-VARS.fd", str(nvram_source)
+    )
+    conn = _make_conn(source_xml=source_xml)
+
+    pool_dir = tmp_path / "pool"
+    pool_dir.mkdir()
+
+    with patch("libvirt.open", return_value=conn), caplog.at_level("WARNING"):
+        runner = LibvirtImageRunner(
+            source_domain="source",
+            suite_name="test",
+            test_name="basic",
+            pool_dir=pool_dir,
+        )
+        try:
+            assert runner.recovery_key is None
+            assert (
+                "Recovery key metadata in source domain 'source' is empty"
+                in caplog.text
+            )
         finally:
             runner.close()

--- a/runner/tests/test_iso_runner.py
+++ b/runner/tests/test_iso_runner.py
@@ -280,6 +280,7 @@ def _make_runner_for_lifecycle(tmp_path: Path) -> LibvirtIsoRunner:
             suite_name="test",
             test_name="basic",
             pool_dir=tmp_path,
+            artifacts_dir=tmp_path / "artifacts",
         )
 
 
@@ -385,5 +386,43 @@ def test_run_yarf_terminates_process_if_still_running(
             asyncio.run(runner._run_yarf("suite", "test", 3, 5900))
 
         mock_process.terminate.assert_called_once()
+    finally:
+        runner.close()
+
+
+def test_store_recovery_key_as_metadata(tmp_path: Path) -> None:
+    runner = _make_runner_for_lifecycle(tmp_path)
+    try:
+        runner.artifacts_path.mkdir(parents=True, exist_ok=True)
+        recovery_key_path = runner.artifacts_path / "recovery-key.txt"
+        recovery_key_path.write_text(
+            "12345-67890-11111-22222-33333-44444-55555-66666\n", encoding="utf-8"
+        )
+        set_metadata_mock = MagicMock()
+        runner.domain.setMetadata = set_metadata_mock
+
+        runner._store_recovery_key_as_metadata()
+
+        set_metadata_mock.assert_called_once_with(
+            libvirt.VIR_DOMAIN_METADATA_ELEMENT,
+            "<ugt><recovery-key>12345-67890-11111-22222-33333-44444-55555-66666</recovery-key></ugt>",
+            "ugt",
+            "https://canonical.com/ubuntu-gui-testing",
+            libvirt.VIR_DOMAIN_AFFECT_CONFIG,
+        )
+    finally:
+        runner.close()
+
+
+def test_store_recovery_key_as_metadata_no_file(tmp_path: Path) -> None:
+    runner = _make_runner_for_lifecycle(tmp_path)
+    try:
+        runner.artifacts_path.mkdir(parents=True, exist_ok=True)
+        set_metadata_mock = MagicMock()
+        runner.domain.setMetadata = set_metadata_mock
+
+        runner._store_recovery_key_as_metadata()
+
+        set_metadata_mock.assert_not_called()
     finally:
         runner.close()

--- a/runner/tests/test_spawn_yarf.py
+++ b/runner/tests/test_spawn_yarf.py
@@ -32,7 +32,10 @@ def test_yarf_command_includes_suite_and_test() -> None:
         runner.artifacts_path = Path("/artifacts")
         asyncio.run(
             runner._spawn_yarf(
-                suite="my-suite", test="my-test", vsock_cid=3, vnc_port=5902
+                suite="my-suite",
+                test="my-test",
+                vnc_port=5902,
+                robot_variables={"CID": "3"},
             )
         )
 
@@ -52,10 +55,42 @@ def test_yarf_command_passes_vsock_cid_as_variable() -> None:
         runner = _FakeRunner.__new__(_FakeRunner)
         runner.artifacts_path = Path("/artifacts")
         asyncio.run(
-            runner._spawn_yarf(suite="suite", test="test", vsock_cid=99, vnc_port=5901)
+            runner._spawn_yarf(
+                suite="suite",
+                test="test",
+                vnc_port=5901,
+                robot_variables={"CID": "99"},
+            )
         )
 
     assert "CID:99" in captured_cmd
+
+
+def test_yarf_command_passes_extra_variables() -> None:
+    captured_cmd: list[str] = []
+
+    async def fake_exec(*args: str, **kwargs: Any) -> AsyncMock:
+        captured_cmd.extend(args)
+        return AsyncMock()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        runner = _FakeRunner.__new__(_FakeRunner)
+        runner.artifacts_path = Path("/artifacts")
+        asyncio.run(
+            runner._spawn_yarf(
+                suite="suite",
+                test="test",
+                vnc_port=5901,
+                robot_variables={
+                    "CID": "99",
+                    "RECOVERY_KEY": "12345-67890-11111-22222-33333-44444-55555-66666",
+                },
+            )
+        )
+
+    assert (
+        "RECOVERY_KEY:12345-67890-11111-22222-33333-44444-55555-66666" in captured_cmd
+    )
 
 
 def test_yarf_sets_vnc_port_env_variable() -> None:
@@ -71,7 +106,12 @@ def test_yarf_sets_vnc_port_env_variable() -> None:
         runner = _FakeRunner.__new__(_FakeRunner)
         runner.artifacts_path = Path("/artifacts")
         asyncio.run(
-            runner._spawn_yarf(suite="suite", test="test", vsock_cid=3, vnc_port=5902)
+            runner._spawn_yarf(
+                suite="suite",
+                test="test",
+                vnc_port=5902,
+                robot_variables={"CID": "3"},
+            )
         )
 
     # VNC port is offset by 5900 (5902 - 5900 = 2)
@@ -89,7 +129,12 @@ def test_yarf_command_uses_configured_artifacts_dir() -> None:
         runner = _FakeRunner.__new__(_FakeRunner)
         runner.artifacts_path = Path("/custom/output")
         asyncio.run(
-            runner._spawn_yarf(suite="suite", test="test", vsock_cid=3, vnc_port=5901)
+            runner._spawn_yarf(
+                suite="suite",
+                test="test",
+                vnc_port=5901,
+                robot_variables={"CID": "3"},
+            )
         )
 
     outdir_idx = captured_cmd.index("--outdir")

--- a/runner/tests/test_ssh.py
+++ b/runner/tests/test_ssh.py
@@ -48,9 +48,7 @@ def test_collects_logs_to_artifacts_directory(tmp_path: Path) -> None:
     mock_sock.connect.assert_called_once_with((42, 22))
 
     # Verify transport was authenticated
-    transport.connect.assert_called_once_with(
-        username="ubuntu", password="ubuntu"
-    )
+    transport.connect.assert_called_once_with(username="ubuntu", password="ubuntu")
 
     # Verify artifacts directory was created
     assert artifacts_dir.exists()

--- a/runner/ubuntu_gui_testing_runner/base.py
+++ b/runner/ubuntu_gui_testing_runner/base.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import defusedxml.ElementTree as ET
 import libvirt  # type: ignore[import-untyped]
 
-from ubuntu_gui_testing_runner.defaults import (
+from ubuntu_gui_testing_runner.constants import (
     DEFAULT_ARTIFACTS_DIR,
     DEFAULT_CONNECTION_URI,
     DEFAULT_POOL_DIR,
@@ -230,7 +230,11 @@ class _BaseLibvirtRunner(Runner):
         self.pool.refresh(0)
 
     async def _spawn_yarf(
-        self, suite: str, test: str, vsock_cid: int, vnc_port: int
+        self,
+        suite: str,
+        test: str,
+        vnc_port: int,
+        robot_variables: dict[str, str],
     ) -> asyncio.subprocess.Process:
         command = [
             "yarf",
@@ -239,11 +243,10 @@ class _BaseLibvirtRunner(Runner):
             "--outdir",
             str(self.artifacts_path),
             "--",
-            "--variable",
-            f"CID:{vsock_cid}",
-            "--suite",
-            test,
         ]
+        for name, value in robot_variables.items():
+            command.extend(["--variable", f"{name}:{value}"])
+        command.extend(["--suite", test])
         env = os.environ.copy()
         env["VNC_PORT"] = str(vnc_port - 5900)
         process = await asyncio.create_subprocess_exec(*command, env=env)

--- a/runner/ubuntu_gui_testing_runner/cli.py
+++ b/runner/ubuntu_gui_testing_runner/cli.py
@@ -1,7 +1,7 @@
 import argparse
 from pathlib import Path
 
-from ubuntu_gui_testing_runner.defaults import (
+from ubuntu_gui_testing_runner.constants import (
     DEFAULT_ARTIFACTS_DIR,
     DEFAULT_CONNECTION_URI,
     DEFAULT_OVERLAY_TEMPLATE,

--- a/runner/ubuntu_gui_testing_runner/constants.py
+++ b/runner/ubuntu_gui_testing_runner/constants.py
@@ -16,3 +16,9 @@ DEFAULT_OVERLAY_TEMPLATE = _TEMPLATE_DIR / "overlay_template.xml"
 DEFAULT_SWTPM_STATE_DIR = Path.home() / ".config/libvirt/qemu/swtpm"
 DEFAULT_TEST_USERNAME = "ubuntu"
 DEFAULT_TEST_PASSWORD = "ubuntu"  # noqa: S105
+
+# Domain metadata constants for libvirt XML persistence
+DOMAIN_METADATA_NAMESPACE = "https://canonical.com/ubuntu-gui-testing"
+DOMAIN_METADATA_ROOT = "ugt"
+RECOVERY_KEY_FILENAME = "recovery-key.txt"
+RECOVERY_KEY_METADATA_KEY = "recovery-key"

--- a/runner/ubuntu_gui_testing_runner/image_runner.py
+++ b/runner/ubuntu_gui_testing_runner/image_runner.py
@@ -12,10 +12,12 @@ import libvirt  # type: ignore[import-untyped]
 from ubuntu_gui_testing_runner.base import (
     _BaseLibvirtRunner,
 )
-from ubuntu_gui_testing_runner.defaults import (
+from ubuntu_gui_testing_runner.constants import (
     DEFAULT_IMAGE_DOMAIN_TEMPLATE,
     DEFAULT_OVERLAY_TEMPLATE,
     DEFAULT_SWTPM_STATE_DIR,
+    DOMAIN_METADATA_NAMESPACE,
+    RECOVERY_KEY_METADATA_KEY,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -34,6 +36,7 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
         **kwargs: Any,
     ) -> None:
         self.source_domain_name = source_domain
+        self.recovery_key: str | None = None
 
         self.overlay_template_path = (
             overlay_template.resolve()
@@ -109,6 +112,37 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
         else:
             self.source_tpm_state_dir = None
 
+        metadata = xml.find("metadata")
+        if metadata is None:
+            LOGGER.info(
+                "No metadata block found in source domain '%s' XML",
+                self.source_domain_name,
+            )
+            return
+
+        key_tag = f"{{{DOMAIN_METADATA_NAMESPACE}}}{RECOVERY_KEY_METADATA_KEY}"
+        elem = metadata.find(f".//{key_tag}")
+        if elem is None:
+            LOGGER.info(
+                "No recovery key metadata found in source domain '%s'",
+                self.source_domain_name,
+            )
+            return
+
+        recovery_key = "" if elem.text is None else elem.text.strip()
+        if not recovery_key:
+            LOGGER.warning(
+                "Recovery key metadata in source domain '%s' is empty",
+                self.source_domain_name,
+            )
+            return
+
+        self.recovery_key = recovery_key
+        LOGGER.info(
+            "Loaded recovery key metadata from source domain '%s'",
+            self.source_domain_name,
+        )
+
     def _create_overlay(self) -> None:
         """Create a qcow2 overlay backed by the original image."""
         volume_xml = self._render_template(
@@ -156,7 +190,24 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
     async def _run_yarf(
         self, suite: str, test: str, vsock_cid: int, vnc_port: int
     ) -> int:
-        yarf_process = await self._spawn_yarf(suite, test, vsock_cid, vnc_port)
+        robot_variables = {"CID": str(vsock_cid)}
+        if self.recovery_key:
+            robot_variables["RECOVERY_KEY"] = self.recovery_key
+            LOGGER.info(
+                "Starting YARF with recovery key variable for source domain '%s'",
+                self.source_domain_name,
+            )
+        else:
+            LOGGER.info(
+                "Starting YARF without recovery key variable for source domain '%s'",
+                self.source_domain_name,
+            )
+        yarf_process = await self._spawn_yarf(
+            suite,
+            test,
+            vnc_port,
+            robot_variables=robot_variables,
+        )
         try:
             returncode = await yarf_process.wait()
             LOGGER.info("YARF process exited with code %s", returncode)

--- a/runner/ubuntu_gui_testing_runner/iso_runner.py
+++ b/runner/ubuntu_gui_testing_runner/iso_runner.py
@@ -5,17 +5,23 @@ import logging
 from pathlib import Path
 from typing import Any
 from xml.etree.ElementTree import tostring as xml_tostring
+from xml.sax.saxutils import escape
 
 import defusedxml.ElementTree as ET
+import libvirt  # type: ignore[import-untyped]
 
 from ubuntu_gui_testing_runner.base import (
     _BaseLibvirtRunner,
 )
-from ubuntu_gui_testing_runner.defaults import (
+from ubuntu_gui_testing_runner.constants import (
     DEFAULT_ISO_DOMAIN_TEMPLATE,
     DEFAULT_TEST_PASSWORD,
     DEFAULT_TEST_USERNAME,
     DEFAULT_VOLUME_TEMPLATE,
+    DOMAIN_METADATA_NAMESPACE,
+    DOMAIN_METADATA_ROOT,
+    RECOVERY_KEY_FILENAME,
+    RECOVERY_KEY_METADATA_KEY,
 )
 from ubuntu_gui_testing_runner.ssh import collect_installer_logs
 
@@ -124,7 +130,12 @@ class LibvirtIsoRunner(_BaseLibvirtRunner):
         If YARF exits before the reboot (e.g. test failure during install),
         we cancel the reboot watcher and return early.
         """
-        yarf_process = await self._spawn_yarf(suite, test, vsock_cid, vnc_port)
+        yarf_process = await self._spawn_yarf(
+            suite,
+            test,
+            vnc_port,
+            robot_variables={"CID": str(vsock_cid)},
+        )
         try:
             async with asyncio.TaskGroup() as tg:
                 yarf_task = tg.create_task(yarf_process.wait())
@@ -155,12 +166,46 @@ class LibvirtIsoRunner(_BaseLibvirtRunner):
                     LOGGER.warning("YARF process did not terminate, killing it")
                     yarf_process.kill()
                     await yarf_process.wait()
+            self._store_recovery_key_as_metadata()
             collect_installer_logs(
                 guest_cid=vsock_cid,
                 test_username=self.test_username,
                 test_password=self.test_password,
                 artifacts_dir=self.artifacts_path,
             )
+
+    def _store_recovery_key_as_metadata(self) -> None:
+        """Read recovery key from artifacts and persist it as libvirt metadata."""
+        recovery_key_path = self.artifacts_path / RECOVERY_KEY_FILENAME
+        if not recovery_key_path.exists():
+            LOGGER.info("Recovery key file '%s' not found", recovery_key_path)
+            return
+
+        recovery_key = recovery_key_path.read_text(encoding="utf-8").strip()
+        if not recovery_key:
+            LOGGER.warning("Recovery key file '%s' is empty", recovery_key_path)
+            return
+
+        metadata_xml = (
+            f"<{DOMAIN_METADATA_ROOT}>"
+            f"<{RECOVERY_KEY_METADATA_KEY}>{escape(recovery_key)}</{RECOVERY_KEY_METADATA_KEY}>"
+            f"</{DOMAIN_METADATA_ROOT}>"
+        )
+        try:
+            self.domain.setMetadata(
+                libvirt.VIR_DOMAIN_METADATA_ELEMENT,
+                metadata_xml,
+                DOMAIN_METADATA_ROOT,
+                DOMAIN_METADATA_NAMESPACE,
+                libvirt.VIR_DOMAIN_AFFECT_CONFIG,
+            )
+        except libvirt.libvirtError:
+            LOGGER.exception(
+                "Failed to store recovery key as metadata for domain '%s'",
+                self.domain_name,
+            )
+            return
+        LOGGER.info("Stored recovery key as metadata for domain '%s'", self.domain_name)
 
     async def _handle_reboot(self) -> None:
         """Poll until the transient domain shuts down, then start the persistent one."""

--- a/tests/desktop-installer/installer.resource
+++ b/tests/desktop-installer/installer.resource
@@ -505,6 +505,8 @@ Wait For TPM Install To Finish
     ...                     Recovery parsed as: ${RECOVERY_KEY}
     ...                     html=true
     ...                     console=true
+    VAR    ${file}    ${OUTPUT DIR}${/}recovery-key.txt
+    Create File    ${file}    ${RECOVERY_KEY}
 
     Keys Combo      Escape
     Move Pointer To "I saved my"


### PR DESCRIPTION
- Persist installer recovery key to artifacts and save into libvirt domain metadata
- Load recovery key from source domain metadata in image runner and pass to YARF as RECOVERY_KEY
- Refactor YARF spawn interface to accept robot_variables map and update callers
- Rename defaults module to constants and centralize domain metadata/recovery key constants
- Expand runner/unit tests for metadata round-trip, variable passing, and realistic key format
- Write parsed recovery key to artifacts in installer Robot resource

UDENG-10598