### PR TITLE
runner: gracefully shut down VM before keeping it

### DIFF
--- a/runner/tests/test_iso_runner.py
+++ b/runner/tests/test_iso_runner.py
@@ -215,6 +215,7 @@ def test_close_destroys_and_undefines_domain_when_keep_is_false(tmp_path: Path) 
         )
         runner.close()
 
+    persistent_domain.shutdown.assert_not_called()
     persistent_domain.destroy.assert_called_once()
     persistent_domain.undefine.assert_called_once()
 
@@ -244,6 +245,91 @@ def test_close_preserves_resources_when_keep_is_true(tmp_path: Path) -> None:
         runner.close()
 
     persistent_domain.destroy.assert_not_called()
+    persistent_domain.undefine.assert_not_called()
+
+
+def _make_keep_runner(tmp_path: Path, persistent_domain: MagicMock) -> LibvirtIsoRunner:
+    """Build a keep=True ISO runner backed by the given persistent domain."""
+    conn = _make_conn()
+
+    iso_file = tmp_path / "test.iso"
+    iso_file.write_text("")
+    iso_path = str(iso_file.resolve())
+
+    transient_domain = MagicMock()
+    transient_domain.XMLDesc.return_value = _iso_domain_xml(iso_path)
+    conn.createXML.return_value = transient_domain
+    conn.defineXML.return_value = persistent_domain
+
+    with patch("libvirt.open", return_value=conn):
+        return LibvirtIsoRunner(
+            iso=str(iso_file),
+            suite_name="test",
+            test_name="basic",
+            keep=True,
+            pool_dir=tmp_path,
+        )
+
+
+def test_close_gracefully_shuts_down_domain_when_keep_is_true(tmp_path: Path) -> None:
+    persistent_domain = MagicMock()
+    # Active on the initial check, then powered off during the poll loop.
+    persistent_domain.isActive.side_effect = [1, 0]
+
+    runner = _make_keep_runner(tmp_path, persistent_domain)
+    runner.close()
+
+    persistent_domain.shutdown.assert_called_once()
+    persistent_domain.destroy.assert_not_called()
+    persistent_domain.undefine.assert_not_called()
+
+
+def test_close_skips_shutdown_when_domain_already_inactive(tmp_path: Path) -> None:
+    persistent_domain = MagicMock()
+    persistent_domain.isActive.return_value = 0
+
+    runner = _make_keep_runner(tmp_path, persistent_domain)
+    runner.close()
+
+    persistent_domain.shutdown.assert_not_called()
+    persistent_domain.destroy.assert_not_called()
+    persistent_domain.undefine.assert_not_called()
+
+
+def test_close_forces_destroy_when_graceful_shutdown_times_out(
+    tmp_path: Path,
+) -> None:
+    persistent_domain = MagicMock()
+    # The guest never powers off, so every isActive check reports active.
+    persistent_domain.isActive.return_value = 1
+
+    runner = _make_keep_runner(tmp_path, persistent_domain)
+    # Advance the monotonic clock past the deadline after one poll iteration
+    # so the timeout branch fires without real sleeping.
+    with (
+        patch(
+            "ubuntu_gui_testing_runner.base.time.monotonic",
+            side_effect=[0.0, 0.0, 999.0],
+        ),
+        patch("ubuntu_gui_testing_runner.base.time.sleep"),
+    ):
+        runner.close()
+
+    persistent_domain.shutdown.assert_called_once()
+    persistent_domain.destroy.assert_called_once()
+    persistent_domain.undefine.assert_not_called()
+
+
+def test_close_forces_destroy_when_graceful_shutdown_errors(tmp_path: Path) -> None:
+    persistent_domain = MagicMock()
+    persistent_domain.isActive.return_value = 1
+    persistent_domain.shutdown.side_effect = libvirt.libvirtError("boom")
+
+    runner = _make_keep_runner(tmp_path, persistent_domain)
+    runner.close()
+
+    persistent_domain.shutdown.assert_called_once()
+    persistent_domain.destroy.assert_called_once()
     persistent_domain.undefine.assert_not_called()
 
 

--- a/runner/ubuntu_gui_testing_runner/base.py
+++ b/runner/ubuntu_gui_testing_runner/base.py
@@ -156,14 +156,19 @@ class _BaseLibvirtRunner(Runner):
         self._pool = None
         self._conn = None
 
-    def _shutdown_domain(self) -> None:
+    def _shutdown_domain(
+        self,
+        timeout: float = GRACEFUL_SHUTDOWN_TIMEOUT,
+        poll_interval: float = GRACEFUL_SHUTDOWN_POLL_INTERVAL,
+    ) -> None:
         """Power off the domain, gracefully first then forcefully on timeout.
 
-        Requests an ACPI shutdown and polls until the domain becomes
-        inactive.  If it does not power off within
-        ``GRACEFUL_SHUTDOWN_TIMEOUT`` seconds, it is forcefully destroyed.
-        Any libvirt error degrades to a forced destroy so teardown can
-        always proceed.
+        Requests an ACPI shutdown and polls every ``poll_interval`` seconds
+        (defaulting to ``GRACEFUL_SHUTDOWN_POLL_INTERVAL``) until the domain
+        becomes inactive.  If it does not power off within ``timeout`` seconds
+        (defaulting to ``GRACEFUL_SHUTDOWN_TIMEOUT``), it is forcefully
+        destroyed.  Any libvirt error degrades to a forced destroy so
+        teardown can always proceed.
         """
         try:
             if self.domain.isActive() != 1:
@@ -182,7 +187,7 @@ class _BaseLibvirtRunner(Runner):
             self._destroy_domain()
             return
 
-        deadline = time.monotonic() + GRACEFUL_SHUTDOWN_TIMEOUT
+        deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             try:
                 if self.domain.isActive() != 1:
@@ -193,12 +198,12 @@ class _BaseLibvirtRunner(Runner):
                     "Failed to query state of domain '%s'", self.domain_name
                 )
                 return
-            time.sleep(GRACEFUL_SHUTDOWN_POLL_INTERVAL)
+            time.sleep(poll_interval)
 
         LOGGER.warning(
             "Domain '%s' did not shut down within %ss, forcing destroy",
             self.domain_name,
-            GRACEFUL_SHUTDOWN_TIMEOUT,
+            timeout,
         )
         self._destroy_domain()
 

--- a/runner/ubuntu_gui_testing_runner/base.py
+++ b/runner/ubuntu_gui_testing_runner/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from abc import abstractmethod
 from datetime import date
 from pathlib import Path
@@ -16,6 +17,8 @@ from ubuntu_gui_testing_runner.constants import (
     DEFAULT_POOL_DIR,
     DEFAULT_POOL_NAME,
     DEFAULT_POOL_TEMPLATE,
+    GRACEFUL_SHUTDOWN_POLL_INTERVAL,
+    GRACEFUL_SHUTDOWN_TIMEOUT,
 )
 from ubuntu_gui_testing_runner.runner import Runner
 
@@ -107,40 +110,40 @@ class _BaseLibvirtRunner(Runner):
             self._pool.refresh(0)
 
         if self.keep:
+            if self._domain is not None:
+                self._shutdown_domain()
             LOGGER.info(
                 "Keeping domain '%s' and associated resources as requested",
                 self.domain_name,
             )
-            return
+        else:
+            if self._domain is not None:
+                self._destroy_domain()
 
-        if self._disk_volume is not None:
-            try:
-                self._disk_volume.delete()
-            except libvirt.libvirtError:
-                LOGGER.exception(
-                    "Failed to delete disk volume '%s'", self.disk_volume_name
-                )
+            if self._disk_volume is not None:
+                try:
+                    self._disk_volume.delete()
+                except libvirt.libvirtError:
+                    LOGGER.exception(
+                        "Failed to delete disk volume '%s'", self.disk_volume_name
+                    )
 
-        if self._pool is not None:
-            try:
-                nvram_volume = self._pool.storageVolLookupByName(self.nvram_volume_name)
-                nvram_volume.delete()
-            except libvirt.libvirtError:
-                LOGGER.exception(
-                    "Failed to delete NVRAM volume '%s'", self.nvram_volume_name
-                )
+            if self._pool is not None:
+                try:
+                    nvram_volume = self._pool.storageVolLookupByName(
+                        self.nvram_volume_name
+                    )
+                    nvram_volume.delete()
+                except libvirt.libvirtError:
+                    LOGGER.exception(
+                        "Failed to delete NVRAM volume '%s'", self.nvram_volume_name
+                    )
 
-        if self._domain is not None:
-            try:
-                if self._domain.isActive() == 1:
-                    self._domain.destroy()
-            except libvirt.libvirtError:
-                LOGGER.exception("Failed to destroy domain '%s'", self.domain_name)
-
-            try:
-                self._domain.undefine()
-            except libvirt.libvirtError:
-                LOGGER.exception("Failed to undefine domain '%s'", self.domain_name)
+            if self._domain is not None:
+                try:
+                    self._domain.undefine()
+                except libvirt.libvirtError:
+                    LOGGER.exception("Failed to undefine domain '%s'", self.domain_name)
 
         if self._conn is not None:
             try:
@@ -152,6 +155,59 @@ class _BaseLibvirtRunner(Runner):
         self._disk_volume = None
         self._pool = None
         self._conn = None
+
+    def _shutdown_domain(self) -> None:
+        """Power off the domain, gracefully first then forcefully on timeout.
+
+        Requests an ACPI shutdown and polls until the domain becomes
+        inactive.  If it does not power off within
+        ``GRACEFUL_SHUTDOWN_TIMEOUT`` seconds, it is forcefully destroyed.
+        Any libvirt error degrades to a forced destroy so teardown can
+        always proceed.
+        """
+        try:
+            if self.domain.isActive() != 1:
+                return
+        except libvirt.libvirtError:
+            LOGGER.exception("Failed to query state of domain '%s'", self.domain_name)
+            return
+
+        LOGGER.info("Requesting graceful shutdown of domain '%s'", self.domain_name)
+        try:
+            self.domain.shutdown()
+        except libvirt.libvirtError:
+            LOGGER.exception(
+                "Failed to request graceful shutdown of domain '%s'", self.domain_name
+            )
+            self._destroy_domain()
+            return
+
+        deadline = time.monotonic() + GRACEFUL_SHUTDOWN_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                if self.domain.isActive() != 1:
+                    LOGGER.info("Domain '%s' shut down gracefully", self.domain_name)
+                    return
+            except libvirt.libvirtError:
+                LOGGER.exception(
+                    "Failed to query state of domain '%s'", self.domain_name
+                )
+                return
+            time.sleep(GRACEFUL_SHUTDOWN_POLL_INTERVAL)
+
+        LOGGER.warning(
+            "Domain '%s' did not shut down within %ss, forcing destroy",
+            self.domain_name,
+            GRACEFUL_SHUTDOWN_TIMEOUT,
+        )
+        self._destroy_domain()
+
+    def _destroy_domain(self) -> None:
+        try:
+            if self.domain.isActive() == 1:
+                self.domain.destroy()
+        except libvirt.libvirtError:
+            LOGGER.exception("Failed to destroy domain '%s'", self.domain_name)
 
     async def _run(self, suite: str, test: str) -> int:
         """Start the domain and log key runtime connectivity properties."""

--- a/runner/ubuntu_gui_testing_runner/constants.py
+++ b/runner/ubuntu_gui_testing_runner/constants.py
@@ -17,6 +17,9 @@ DEFAULT_SWTPM_STATE_DIR = Path.home() / ".config/libvirt/qemu/swtpm"
 DEFAULT_TEST_USERNAME = "ubuntu"
 DEFAULT_TEST_PASSWORD = "ubuntu"  # noqa: S105
 
+GRACEFUL_SHUTDOWN_TIMEOUT = 30
+GRACEFUL_SHUTDOWN_POLL_INTERVAL = 1
+
 # Domain metadata constants for libvirt XML persistence
 DOMAIN_METADATA_NAMESPACE = "https://canonical.com/ubuntu-gui-testing"
 DOMAIN_METADATA_ROOT = "ugt"


### PR DESCRIPTION
Currently using `--keep` with the iso runner leaves the preserved VM in a running state, preventing subsequent runs that re-use this VM with the image runner to access the disk. This PR ensures that the VM is powered down at the end of the test.

UDENG-10599