### PR TITLE
feat(runner): add support for mounting source domain as USB disk

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -26,6 +26,23 @@ ubuntu-gui-testing-runner \
   --source-domain ugt-desktop-installer-resolute.entire-disk-2026-06-01
 ```
 
+### From an existing domain with source disk mounted as USB
+
+When cloning from an existing domain, you can optionally attach a second overlay
+of the same source image as a USB disk. This is useful for tests that need to
+mount or unlock a secondary device.
+
+```bash
+ubuntu-gui-testing-runner \
+  --suite tests/snap-tpmctl \
+  --test snap-tpmctl-mount \
+  --source-domain ugt-desktop-installer-resolute.entire-disk-2026-06-01 \
+  --mount-source-domain /dev/sda5
+```
+
+If `--mount-source-domain` is passed without a value, the default device is
+`/dev/sda`.
+
 ### Options
 
 | Flag | Description |
@@ -34,6 +51,7 @@ ubuntu-gui-testing-runner \
 | `--test` | Name of the test to run (required) |
 | `--iso` | Path to an ISO for installation |
 | `--source-domain` | Existing libvirt domain to clone from |
+| `--mount-source-domain [DEVICE]` | Attach a second overlay of the source domain as a USB disk and pass `DEVICE` to Robot variables |
 | `--keep` | Keep the VM and resources after the run |
 | `--connection-uri` | Libvirt connection URI (default: `qemu:///session`) |
 | `--pool-name` | Storage pool name (default: `ubuntu-gui-testing`) |

--- a/runner/templates/image_domain_template.xml
+++ b/runner/templates/image_domain_template.xml
@@ -38,6 +38,7 @@
       <source file="{disk}"/>
       <target dev="vda" bus="virtio"/>
     </disk>
+    {usb_disk}
     <interface type="user">
       <model type="virtio"/>
     </interface>

--- a/runner/tests/test_cli.py
+++ b/runner/tests/test_cli.py
@@ -84,3 +84,44 @@ def test_keep_flag_set_to_true(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     args = parse_args()
     assert args.keep is True
+
+
+def test_mount_source_domain_defaults_to_sda(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "runner",
+            "--suite",
+            "s",
+            "--test",
+            "t",
+            "--source-domain",
+            "d",
+            "--mount-source-domain",
+        ],
+    )
+    args = parse_args()
+    assert args.mount_source_domain == "/dev/sda"
+
+
+def test_mount_source_domain_accepts_device(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "runner",
+            "--suite",
+            "s",
+            "--test",
+            "t",
+            "--source-domain",
+            "d",
+            "--mount-source-domain",
+            "/dev/sdb",
+        ],
+    )
+    args = parse_args()
+    assert args.mount_source_domain == "/dev/sdb"

--- a/runner/tests/test_image_runner.py
+++ b/runner/tests/test_image_runner.py
@@ -344,6 +344,72 @@ def test_run_yarf_passes_recovery_key_variable_when_present(tmp_path: Path) -> N
             runner.close()
 
 
+def test_run_yarf_passes_device_when_mount_source_domain_is_enabled(
+    tmp_path: Path,
+) -> None:
+    nvram_source = tmp_path / "source-VARS.fd"
+    nvram_source.write_bytes(b"nvram-data")
+
+    source_xml = SOURCE_DOMAIN_XML.replace("/pool/source-VARS.fd", str(nvram_source))
+    conn = _make_conn(source_xml=source_xml)
+
+    pool_dir = tmp_path / "pool"
+    pool_dir.mkdir()
+
+    with patch("libvirt.open", return_value=conn):
+        runner = LibvirtImageRunner(
+            source_domain="source",
+            suite_name="test",
+            test_name="basic",
+            pool_dir=pool_dir,
+            mount_source_domain="/dev/sdb",
+        )
+        try:
+            mock_process = AsyncMock()
+            mock_process.wait = AsyncMock(return_value=0)
+            mock_process.returncode = 0
+            with patch.object(
+                runner, "_spawn_yarf", return_value=mock_process
+            ) as spawn:
+                asyncio.run(runner._run_yarf("suite", "test", 3, 5901))
+
+            spawn.assert_called_once_with(
+                "suite",
+                "test",
+                5901,
+                robot_variables={"CID": "3", "DEVICE": "/dev/sdb"},
+            )
+        finally:
+            runner.close()
+
+
+def test_mount_source_domain_uses_matching_usb_target(
+    tmp_path: Path,
+) -> None:
+    nvram_source = tmp_path / "source-VARS.fd"
+    nvram_source.write_bytes(b"nvram-data")
+
+    source_xml = SOURCE_DOMAIN_XML.replace("/pool/source-VARS.fd", str(nvram_source))
+    conn = _make_conn(source_xml=source_xml)
+
+    pool_dir = tmp_path / "pool"
+    pool_dir.mkdir()
+
+    with patch("libvirt.open", return_value=conn):
+        runner = LibvirtImageRunner(
+            source_domain="source",
+            suite_name="test",
+            test_name="basic",
+            pool_dir=pool_dir,
+            mount_source_domain="/dev/sdb1",
+        )
+        try:
+            domain_xml = conn.defineXML.call_args.args[0]
+            assert '<target dev="sdb" bus="usb"/>' in domain_xml
+        finally:
+            runner.close()
+
+
 def test_logs_when_recovery_key_metadata_missing(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,

--- a/runner/ubuntu_gui_testing_runner/__main__.py
+++ b/runner/ubuntu_gui_testing_runner/__main__.py
@@ -38,6 +38,7 @@ def main() -> None:
             keep=args.keep,
             domain_template=args.domain_template,
             overlay_template=args.overlay_template,
+            mount_source_domain=args.mount_source_domain,
             pool_template=args.pool_template,
             artifacts_dir=args.artifacts_dir,
             connection_uri=args.connection_uri,

--- a/runner/ubuntu_gui_testing_runner/base.py
+++ b/runner/ubuntu_gui_testing_runner/base.py
@@ -58,12 +58,14 @@ class _BaseLibvirtRunner(Runner):
         self._conn: libvirt.virConnect | None = None
         self._pool: libvirt.virStoragePool | None = None
         self._disk_volume: libvirt.virStorageVol | None = None
+        self._usb_disk_volume: libvirt.virStorageVol | None = None
         self._domain: libvirt.virDomain | None = None
 
         try:
             self._open_connection()
             self.domain_name = self._generate_domain_name(suite_name, test_name)
             self.disk_volume_name = f"{self.domain_name}.qcow2"
+            self.usb_disk_volume_name = f"{self.domain_name}-usb.qcow2"
             self.nvram_volume_name = f"{self.domain_name}-VARS.fd"
             self._ensure_pool()
             self._setup()
@@ -128,6 +130,15 @@ class _BaseLibvirtRunner(Runner):
                         "Failed to delete disk volume '%s'", self.disk_volume_name
                     )
 
+            if self._usb_disk_volume is not None:
+                try:
+                    self._usb_disk_volume.delete()
+                except libvirt.libvirtError:
+                    LOGGER.exception(
+                        "Failed to delete USB disk volume '%s'",
+                        self.usb_disk_volume_name,
+                    )
+
             if self._pool is not None:
                 try:
                     nvram_volume = self._pool.storageVolLookupByName(
@@ -153,6 +164,7 @@ class _BaseLibvirtRunner(Runner):
 
         self._domain = None
         self._disk_volume = None
+        self._usb_disk_volume = None
         self._pool = None
         self._conn = None
 

--- a/runner/ubuntu_gui_testing_runner/cli.py
+++ b/runner/ubuntu_gui_testing_runner/cli.py
@@ -32,6 +32,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Keep the domain and resources after the run completes",
     )
+    parser.add_argument(
+        "--mount-source-domain",
+        nargs="?",
+        const="/dev/sda",
+        default=None,
+        metavar="DEVICE",
+        help="Attach a second overlay of the source domain as a USB disk",
+    )
 
     source = parser.add_mutually_exclusive_group(required=True)
     source.add_argument(

--- a/runner/ubuntu_gui_testing_runner/image_runner.py
+++ b/runner/ubuntu_gui_testing_runner/image_runner.py
@@ -33,10 +33,12 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
         test_name: str,
         domain_template: Path | None = None,
         overlay_template: Path | None = None,
+        mount_source_domain: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.source_domain_name = source_domain
         self.recovery_key: str | None = None
+        self.mount_source_domain = mount_source_domain
 
         self.overlay_template_path = (
             overlay_template.resolve()
@@ -144,12 +146,24 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
         )
 
     def _create_overlay(self) -> None:
-        """Create a qcow2 overlay backed by the original image."""
+        """Create qcow2 overlays backed by the original image."""
         volume_xml = self._render_template(
             self.overlay_template_path,
             {"name": self.disk_volume_name, "backing_image": str(self.image_path)},
         )
         self._disk_volume = self.pool.createXML(volume_xml, 0)
+
+        if self.mount_source_domain is None:
+            return
+
+        usb_volume_xml = self._render_template(
+            self.overlay_template_path,
+            {
+                "name": self.usb_disk_volume_name,
+                "backing_image": str(self.image_path),
+            },
+        )
+        self._usb_disk_volume = self.pool.createXML(usb_volume_xml, 0)
 
     def _copy_nvram(self) -> None:
         """Copy the NVRAM file into the pool, leaving the original untouched."""
@@ -179,6 +193,7 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
             {
                 "name": self.domain_name,
                 "disk": str(self.pool_dir / self.disk_volume_name),
+                "usb_disk": self._usb_disk_xml(),
                 "nvram": str(self.pool_dir / self.nvram_volume_name),
             },
         )
@@ -187,10 +202,32 @@ class LibvirtImageRunner(_BaseLibvirtRunner):
         if self._domain is None:
             raise RuntimeError(f"Unable to define domain '{self.domain_name}'")
 
+    def _usb_disk_xml(self) -> str:
+        if self.mount_source_domain is None:
+            return ""
+
+        usb_disk = self.pool_dir / self.usb_disk_volume_name
+        target_dev = self._usb_disk_target_dev()
+        return f"""    <disk type="file" device="disk">
+      <driver name="qemu" type="qcow2" discard="unmap"/>
+      <source file="{usb_disk}"/>
+      <target dev="{target_dev}" bus="usb"/>
+    </disk>"""
+
+    def _usb_disk_target_dev(self) -> str:
+        if self.mount_source_domain is None:
+            return "sda"
+
+        # Libvirt needs the whole-disk target (e.g. sda), while Robot gets the
+        # partition path to mount (e.g. /dev/sda5).
+        return Path(self.mount_source_domain).name.rstrip("0123456789")
+
     async def _run_yarf(
         self, suite: str, test: str, vsock_cid: int, vnc_port: int
     ) -> int:
         robot_variables = {"CID": str(vsock_cid)}
+        if self.mount_source_domain is not None:
+            robot_variables["DEVICE"] = self.mount_source_domain
         if self.recovery_key:
             robot_variables["RECOVERY_KEY"] = self.recovery_key
             LOGGER.info(


### PR DESCRIPTION
For exercising the `mount` and `unmount` features, `snap-tpmctl` needs a TPM encrypted volume with a known recovery key. 

This PR adds an optional mode to the image runner to attach a second overlay of the source domain disk as a USB device in the cloned VM.

When the `--mount-source-domain <device>` CLI option is enabled, it takes the expected device as an argument (e.g. `/dev/sda5`), create an extra overlay form the same backing image and attaches it as a USB volume (in this case `/dev/sda`). The submodule name is then passed to YARF/Robot under the variable named `DEVICE` and can be accessed in tests.

The existing recovery key is the same for the image and the device, and it's propagated under the `RECOVERY_KEY` variable from the domain metadata.

An example of usage would be:

1. Creating a new domain with

```bash
ubuntu-gui-testing-runner --suite tests/desktop-installer --test stonking.tpm-fde-no-passphrase --iso ~/images/stonking-desktop-amd64.iso --pool-dir ~/pool --keep
```

2. After the installation process, run the tests 

```bash
ubuntu-gui-testing-runner --suite tests/snap-tpmctl --test Snap-Tpmctl-Mount --source-domain ugt-desktop-installer-stonking.tpm-fde-no-passphrase --pool-dir ~/pool --mount-source-domain /dev/sda5
```

